### PR TITLE
WEBSITE_INSTANCE_ID as consumer name

### DIFF
--- a/src/StreamTrigger/RedisStreamListener.cs
+++ b/src/StreamTrigger/RedisStreamListener.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         {
             this.consumerGroup = consumerGroup;
             this.deleteAfterProcess = deleteAfterProcess;
-            this.consumerName = Guid.NewGuid().ToString();
+            this.consumerName = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") ?? Guid.NewGuid().ToString();
 
             this.logPrefix = $"[Name:{name}][Trigger:RedisStreamTrigger][ConsumerGroup:{consumerGroup}][Key:{key}][Consumer:{consumerName}]";
             this.Descriptor = new ScaleMonitorDescriptor(name, $"{name}-RedisStreamTrigger-{consumerGroup}-{key}");


### PR DESCRIPTION
attempt to pull environment variable WEBSITE_INSTANCE_ID to use as consumer name instead of random guid, but default to random guid if not found.

This specific environment variable is listed here: https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#scaling