### PR TITLE
Add TargetBasedScaling integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ trigger:
       - main
 
 variables:
+  FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: '1'
   # It is a release build if it is triggered by the main branch.
   isReleaseBuild: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/main') }}
   majorVersion: 0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,8 @@ jobs:
         inputs:
           targetType: 'inline'
           script: 'wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb; sudo dpkg -i packages-microsoft-prod.deb; sudo apt-get update; sudo apt-get install -qq -y azure-functions-core-tools-4'
+        env:
+          FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: 1
 
       - task: Bash@3
         displayName: Download and start redis server, enable all keyspace/keyevent notifications
@@ -52,6 +54,8 @@ jobs:
         inputs:
           command: test
           arguments: $(Build.SourcesDirectory)/test/dotnet/Microsoft.Azure.WebJobs.Extensions.Redis.Tests.csproj --configuration Debug
+        env:
+          FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: 1
 
       - task: DotNetCoreCLI@2
         displayName: Build Microsoft.Azure.WebJobs.Extensions.Redis Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,6 @@ jobs:
         inputs:
           targetType: 'inline'
           script: 'wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb; sudo dpkg -i packages-microsoft-prod.deb; sudo apt-get update; sudo apt-get install -qq -y azure-functions-core-tools-4'
-        env:
-          FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: 1
 
       - task: Bash@3
         displayName: Download and start redis server, enable all keyspace/keyevent notifications
@@ -54,8 +52,6 @@ jobs:
         inputs:
           command: test
           arguments: $(Build.SourcesDirectory)/test/dotnet/Microsoft.Azure.WebJobs.Extensions.Redis.Tests.csproj --configuration Debug
-        env:
-          FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: 1
 
       - task: DotNetCoreCLI@2
         displayName: Build Microsoft.Azure.WebJobs.Extensions.Redis Release

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,9 +49,9 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: Test Microsoft.Azure.WebJobs.Extensions.Redis Debug
+        env:
+          FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: '1'
         inputs:
-          env:
-            FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: '1'
           command: test
           arguments: $(Build.SourcesDirectory)/test/dotnet/Microsoft.Azure.WebJobs.Extensions.Redis.Tests.csproj --configuration Debug
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ trigger:
       - main
 
 variables:
-  FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: 1
   # It is a release build if it is triggered by the main branch.
   isReleaseBuild: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/main') }}
   majorVersion: 0
@@ -51,6 +50,8 @@ jobs:
       - task: DotNetCoreCLI@2
         displayName: Test Microsoft.Azure.WebJobs.Extensions.Redis Debug
         inputs:
+          env:
+            FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: '1'
           command: test
           arguments: $(Build.SourcesDirectory)/test/dotnet/Microsoft.Azure.WebJobs.Extensions.Redis.Tests.csproj --configuration Debug
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ trigger:
       - main
 
 variables:
+  FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: 1
   # It is a release build if it is triggered by the main branch.
   isReleaseBuild: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/main') }}
   majorVersion: 0
@@ -40,12 +41,6 @@ jobs:
         inputs:
           targetType: 'inline'
           script: 'wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb; sudo dpkg -i packages-microsoft-prod.deb; sudo apt-get update; sudo apt-get install -qq -y azure-functions-core-tools-4'
-
-      - task: Bash@3
-        displayName: Set Environment Variables
-        inputs:
-          targetType: 'inline'
-          script: 'echo '##vso[task.setvariable variable=FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED]1'
 
       - task: Bash@3
         displayName: Download and start redis server, enable all keyspace/keyevent notifications

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,6 @@ trigger:
       - main
 
 variables:
-  FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: '1'
   # It is a release build if it is triggered by the main branch.
   isReleaseBuild: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/main') }}
   majorVersion: 0
@@ -50,8 +49,6 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: Test Microsoft.Azure.WebJobs.Extensions.Redis Debug
-        env:
-          FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED: '1'
         inputs:
           command: test
           arguments: $(Build.SourcesDirectory)/test/dotnet/Microsoft.Azure.WebJobs.Extensions.Redis.Tests.csproj --configuration Debug

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,12 @@ jobs:
           script: 'wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb; sudo dpkg -i packages-microsoft-prod.deb; sudo apt-get update; sudo apt-get install -qq -y azure-functions-core-tools-4'
 
       - task: Bash@3
+        displayName: Set Environment Variables
+        inputs:
+          targetType: 'inline'
+          script: 'echo '##vso[task.setvariable variable=FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED]1'
+
+      - task: Bash@3
         displayName: Download and start redis server, enable all keyspace/keyevent notifications
         inputs:
           targetType: 'inline'

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -14,20 +14,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     {
         internal static Process StartFunction(string functionName, int port)
         {
-            Process functionsProcess = new Process
+            ProcessStartInfo info = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = GetFunctionsFileName(),
-                    Arguments = $"start --verbose --functions {functionName} --port {port} --no-build --prefix {GetPrefix()}",
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    WorkingDirectory = new DirectoryInfo(Directory.GetCurrentDirectory()).Parent.Parent.Parent.FullName,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false
-                }
+                FileName = GetFunctionsFileName(),
+                Arguments = $"start --verbose --functions {functionName} --port {port} --no-build --prefix {GetPrefix()}",
+                WindowStyle = ProcessWindowStyle.Hidden,
+                WorkingDirectory = new DirectoryInfo(Directory.GetCurrentDirectory()).Parent.Parent.Parent.FullName,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
             };
-            functionsProcess.StartInfo.EnvironmentVariables["FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED"] = "1";
+            info.EnvironmentVariables["FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED"] = "1";
+            Process functionsProcess = new Process() { StartInfo = info };
 
             TaskCompletionSource<bool> hostStarted = new TaskCompletionSource<bool>();
             void hostStartupHandler(object sender, DataReceivedEventArgs e)

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -108,10 +108,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             return value.GetType().FullName + ":" + JsonConvert.SerializeObject(value);
         }
 
-        internal class ScaleStatus
+        public class ScaleStatus
         {
-            internal int vote;
-            internal int targetWorkerCount;
+            public int vote;
+            public int targetWorkerCount;
         }
     }
 }

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
                     UseShellExecute = false
                 }
             };
+            functionsProcess.StartInfo.EnvironmentVariables["FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED"] = "1";
 
             TaskCompletionSource<bool> hostStarted = new TaskCompletionSource<bool>();
             void hostStartupHandler(object sender, DataReceivedEventArgs e)

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     {
         internal static Process StartFunction(string functionName, int port)
         {
+            Environment.SetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED", "1");
+            Environment.SetEnvironmentVariable("TARGET_BASED_SCALING_ENABLED", "1");
+
             Process functionsProcess = new Process
             {
                 StartInfo = new ProcessStartInfo
@@ -103,6 +106,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         internal static string GetLogValue(object value)
         {
             return value.GetType().FullName + ":" + JsonConvert.SerializeObject(value);
+        }
+
+        internal class ScaleStatus
+        {
+            internal int vote;
+            internal int targetWorkerCount;
         }
     }
 }

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -14,9 +14,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     {
         internal static Process StartFunction(string functionName, int port)
         {
-            Environment.SetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED", "1");
-            Environment.SetEnvironmentVariable("TARGET_BASED_SCALING_ENABLED", "1");
-
             Process functionsProcess = new Process
             {
                 StartInfo = new ProcessStartInfo

--- a/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
@@ -6,11 +6,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     public static class RedisListTriggerTestFunctions
     {
         public const string localhostSetting = "redisLocalhost";
-        public const int pollingInterval = 100;
+        public const int pollingIntervalShort = 100;
+        public const int pollingIntervalLong = 10000;
 
         [FunctionName(nameof(ListTrigger_RedisValue))]
         public static void ListTrigger_RedisValue(
-            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue), pollingIntervalInMs: pollingInterval)] RedisValue entry,
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue), pollingIntervalInMs: pollingIntervalShort)] RedisValue entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
@@ -18,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(ListTrigger_String))]
         public static void ListTrigger_String(
-            [RedisListTrigger(localhostSetting, nameof(ListTrigger_String), pollingIntervalInMs: pollingInterval)] string entry,
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_String), pollingIntervalInMs: pollingIntervalShort)] string entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(ListTrigger_ByteArray))]
         public static void ListTrigger_ByteArray(
-            [RedisListTrigger(localhostSetting, nameof(ListTrigger_ByteArray), pollingIntervalInMs: pollingInterval)] byte[] entry,
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_ByteArray), pollingIntervalInMs: pollingIntervalShort)] byte[] entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
@@ -34,7 +35,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(ListTrigger_CustomType))]
         public static void ListTrigger_CustomType(
-            [RedisListTrigger(localhostSetting, nameof(ListTrigger_CustomType), pollingIntervalInMs: pollingInterval)] CustomType entry,
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_CustomType), pollingIntervalInMs: pollingIntervalShort)] CustomType entry,
+            ILogger logger)
+        {
+            logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
+        }
+
+        [FunctionName(nameof(ListTrigger_RedisValue_LongPollingInterval))]
+        public static void ListTrigger_RedisValue_LongPollingInterval(
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue_LongPollingInterval), pollingIntervalInMs: pollingIntervalLong, messagesPerWorker: 1, count: 1)] RedisValue entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             };
 
             Assert.Equal(1, status.vote);
-            Assert.Equal(elements - 1, status.targetWorkerCount);
+            Assert.True(status.targetWorkerCount / (float) elements > 0.999);
         }
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -107,34 +107,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
 
-        [Fact]
-        public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
-        {
-            string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
-            int port = 7071;
-            int elements = 10000;
-            RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
+        //Target Scaler Integration Tests not required.
+        // Keeping this as a manual test for local development.
+        //[Fact]
+        //public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
+        //{
+        //    string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
+        //    int port = 7071;
+        //    int elements = 10000;
+        //    RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
 
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
-            {
-                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
-                await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
-                await multiplexer.CloseAsync();
-            };
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+        //    {
+        //        await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+        //        await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
+        //        await multiplexer.CloseAsync();
+        //    };
 
-            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-            using (HttpClient client = new HttpClient())
-            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-            {
-                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-                functionsProcess.Kill();
-            };
+        //    IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+        //    using (HttpClient client = new HttpClient())
+        //    using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+        //    {
+        //        StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+        //        HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+        //        status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+        //        functionsProcess.Kill();
+        //    };
 
-            Assert.Equal(1, status.vote);
-            Assert.True(status.targetWorkerCount / (float) elements > 0.999);
-        }
+        //    Assert.Equal(1, status.vote);
+        //    Assert.True(status.targetWorkerCount / (float) elements > 0.999);
+        //}
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
             using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
             {
+                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
                 await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
                 await multiplexer.CloseAsync();
             };

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -110,36 +110,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         [Fact]
         public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
         {
-            throw new Exception(Environment.GetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED"));
-            //if (monitoringEnabled != "1")
-            //{
-            //    throw new Exception("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, cannot attempt to check status");
-            //}
+            string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
+            int port = 7071;
+            int elements = 10000;
+            RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
 
-            //string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
-            //int port = 7071;
-            //int elements = 10000;
-            //RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            {
+                await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
+                await multiplexer.CloseAsync();
+            };
 
-            //using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
-            //{
-            //    await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
-            //    await multiplexer.CloseAsync();
-            //};
+            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+            using (HttpClient client = new HttpClient())
+            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+            {
+                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+                try
+                {
+                    HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+                    status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+                }
+                catch (HttpRequestException ex)
+                {
+                    //Environment variable FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, so test will not work.
+                }
+                functionsProcess.Kill();
+            };
 
-            //IntegrationTestHelpers.ScaleStatus status;
-            //using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-            //using (HttpClient client = new HttpClient())
-            //using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-            //{
-            //    StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-            //    HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-            //    status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-            //    functionsProcess.Kill();
-            //};
-
-            //Assert.Equal(1, status.vote);
-            //Assert.Equal(elements - 1, status.targetWorkerCount);
+            Assert.Equal(1, status.vote);
+            Assert.Equal(elements - 1, status.targetWorkerCount);
         }
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -107,42 +107,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
 
-        [Fact]
-        public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
-        {
-            string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
-            int port = 7071;
-            int elements = 10000;
-            RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
+        //Target Scaler Integration Tests not required.
+        // Keeping this as a manual test for local development.
+        //[Fact]
+        //public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
+        //{
+        //    string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
+        //    int port = 7071;
+        //    int elements = 10000;
+        //    RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
 
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
-            {
-                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
-                await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
-                await multiplexer.CloseAsync();
-            };
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+        //    {
+        //        await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+        //        await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
+        //        await multiplexer.CloseAsync();
+        //    };
 
-            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-            using (HttpClient client = new HttpClient())
-            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-            {
-                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-                try
-                {
-                    HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                    status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-                }
-                catch (HttpRequestException ex)
-                {
-                    // In the case where the admin endpoint for the functions process does not respond
-                    // Catch exception to ensure that functions process is killed and other tests complete successfully
-                }
-                functionsProcess.Kill();
-            };
+        //    IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+        //    using (HttpClient client = new HttpClient())
+        //    using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+        //    {
+        //        StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+        //        HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+        //        status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+        //        functionsProcess.Kill();
+        //    };
 
-            Assert.Equal(1, status.vote);
-            Assert.True(status.targetWorkerCount / (float)elements > 0.999);
-        }
+        //    Assert.Equal(1, status.vote);
+        //    Assert.True(status.targetWorkerCount / (float) elements > 0.999);
+        //}
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -110,6 +110,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         [Fact]
         public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
         {
+            string monitoringEnabled = Environment.GetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED");
+            if (monitoringEnabled.IsNullOrEmpty() || monitoringEnabled != "1")
+            {
+                throw new Exception("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, cannot attempt to check status");
+            }
+
             string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
             int port = 7071;
             int elements = 10000;

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -127,15 +127,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
             {
                 StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-                try
-                {
-                    HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                    status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-                }
-                catch (HttpRequestException ex)
-                {
-                    //Environment variable FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, so test will not work.
-                }
+                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
                 functionsProcess.Kill();
             };
 

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -110,36 +110,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         [Fact]
         public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
         {
-            string monitoringEnabled = Environment.GetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED");
-            if (monitoringEnabled != "1")
-            {
-                throw new Exception("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, cannot attempt to check status");
-            }
+            throw new Exception(Environment.GetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED"));
+            //if (monitoringEnabled != "1")
+            //{
+            //    throw new Exception("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, cannot attempt to check status");
+            //}
 
-            string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
-            int port = 7071;
-            int elements = 10000;
-            RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
+            //string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
+            //int port = 7071;
+            //int elements = 10000;
+            //RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
 
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
-            {
-                await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
-                await multiplexer.CloseAsync();
-            };
+            //using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            //{
+            //    await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
+            //    await multiplexer.CloseAsync();
+            //};
 
-            IntegrationTestHelpers.ScaleStatus status;
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-            using (HttpClient client = new HttpClient())
-            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-            {
-                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-                functionsProcess.Kill();
-            };
+            //IntegrationTestHelpers.ScaleStatus status;
+            //using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+            //using (HttpClient client = new HttpClient())
+            //using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+            //{
+            //    StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+            //    HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+            //    status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+            //    functionsProcess.Kill();
+            //};
 
-            Assert.Equal(1, status.vote);
-            Assert.Equal(elements - 1, status.targetWorkerCount);
+            //Assert.Equal(1, status.vote);
+            //Assert.Equal(elements - 1, status.targetWorkerCount);
         }
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
         {
             string monitoringEnabled = Environment.GetEnvironmentVariable("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED");
-            if (monitoringEnabled.IsNullOrEmpty() || monitoringEnabled != "1")
+            if (monitoringEnabled != "1")
             {
                 throw new Exception("FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED not set to 1, cannot attempt to check status");
             }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -7,9 +7,7 @@ using Newtonsoft.Json;
 using System.Threading.Tasks;
 using System.Net.Http;
 using Xunit;
-using System.Collections.Generic;
 using System.Text;
-using static Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration.IntegrationTestHelpers;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 {
@@ -123,19 +121,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
                 await multiplexer.CloseAsync();
             };
 
-            ScaleStatus status;
+            IntegrationTestHelpers.ScaleStatus status;
             using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
             using (HttpClient client = new HttpClient())
             using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
             {
                 StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
                 HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                status = JsonConvert.DeserializeObject<ScaleStatus>(await response.Content.ReadAsStringAsync());
+                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
                 functionsProcess.Kill();
             };
 
             Assert.Equal(1, status.vote);
-            Assert.Equal(elements, status.targetWorkerCount - 1);
+            Assert.Equal(elements - 1, status.targetWorkerCount);
         }
     }
 }


### PR DESCRIPTION
Adds unit tests for the target scaler, and a commented out integration tests that uses `admin/host/scale/status` to get expected target count from host.