### PR TITLE
Sample Function templates for Redis to CosmosDB Synchronization using the Redis Stream Trigger 

### DIFF
--- a/samples/CosmosDBIntegration/Models/RedisData.cs
+++ b/samples/CosmosDBIntegration/Models/RedisData.cs
@@ -6,26 +6,64 @@ using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples.Models
 {
-    public class CosmosDBData
+    public class StreamData
     {
         public string id { get; set; }
         public Dictionary<string, string> values { get; set; }
 
         // Helper method to format stream message
-        public static CosmosDBData Format(StreamEntry entry, ILogger logger)
+        public static StreamData Format(StreamEntry entry, ILogger logger)
         {
             logger.LogInformation("ID: {val}", entry.Id.ToString());
 
             // Map each key value pair
-            Dictionary<string, string> dict = StreamEntryToDictionary(entry);
+            Dictionary<string, string> dict = RedisUtilities.StreamEntryToDictionary(entry);
 
-            CosmosDBData sampleItem = new CosmosDBData { id = entry.Id, values = dict };
+            StreamData sampleItem = new StreamData { id = entry.Id, values = dict };
             return sampleItem;
         }
+    }
 
-        internal static Dictionary<string, string> StreamEntryToDictionary(StreamEntry entry)
+    public class StreamDataSingleDocument
+    {
+        public string id { get; set; }
+        public int maxlen { get; set; }
+        public Dictionary<string, Dictionary<string, string>> messages { get; set; }
+
+        public static StreamDataSingleDocument CreateNewEntry(StreamEntry entry, string streamName, ILogger logger)
         {
-            return entry.Values.ToDictionary((NameValueEntry value) => value.Name.ToString(), (NameValueEntry value) => value.Value.ToString());
+            logger.LogInformation("Creating a new document for {val}. Inserting ID: {val} as the first entry", streamName, entry.Id.ToString());
+
+            // Map each key value pair
+            Dictionary<string, string> dict = RedisUtilities.StreamEntryToDictionary(entry);
+
+            // Create a new list of messages
+            var list = new Dictionary<string, Dictionary<string, string>>();
+            list.Add(entry.Id.ToString(), dict);
+
+            StreamDataSingleDocument data = new StreamDataSingleDocument { id = streamName, maxlen = 1000, messages = list };
+            return data;
+        }
+
+        public static StreamDataSingleDocument UpdateExistingEntry(StreamDataSingleDocument results, StreamEntry entry, ILogger logger)
+        {
+            logger.LogInformation("Adding to {val} document. Inserting ID: {val} ", results.id, entry.Id.ToString());
+
+            // Map each key value pair
+            Dictionary<string, string> dict = RedisUtilities.StreamEntryToDictionary(entry);
+
+            // Update list of messages
+            var list = results.messages;
+            list.Add(entry.Id.ToString(), dict);
+
+            if (list.Count > results.maxlen)
+            {
+                string minKey = list.Keys.Min();
+                list.Remove(minKey);
+            }
+
+            StreamDataSingleDocument data = new StreamDataSingleDocument { id = results.id, maxlen = results.maxlen, messages = list };
+            return data;
         }
     }
 

--- a/samples/CosmosDBIntegration/ReadThroughSamples/ReadThroughSamples.csproj
+++ b/samples/CosmosDBIntegration/ReadThroughSamples/ReadThroughSamples.csproj
@@ -10,11 +10,12 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.3.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Redis" Version="0.3.1-preview" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.2" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.Azure.Functions.Worker.Extensions.Redis\Microsoft.Azure.Functions.Worker.Extensions.Redis.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs.Extensions.Redis\Microsoft.Azure.WebJobs.Extensions.Redis.csproj" />
+    <ProjectReference Include="..\..\dotnet\Microsoft.Azure.WebJobs.Extensions.Redis.Samples.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/CosmosDBIntegration/ReadThroughSamples/StreamSample.cs
+++ b/samples/CosmosDBIntegration/ReadThroughSamples/StreamSample.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
+using Microsoft.Azure.WebJobs.Extensions.Redis.Samples.Models;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
+{
+    internal class StreamSample
+    {
+        // Redis connection string and stream names stored in local.settings.json
+        public const string RedisConnectionSetting = "RedisConnectionString";
+        private static readonly Lazy<IDatabaseAsync> _redisDB = new Lazy<IDatabaseAsync>(() =>
+           ConnectionMultiplexer.Connect(Environment.GetEnvironmentVariable(RedisConnectionSetting)).GetDatabase());
+        public static string StreamNameSingleDocument = Environment.GetEnvironmentVariable("StreamTest");
+
+        // CosmosDB connection string, database name and container name stored in local.settings.json
+        public const string CosmosDbConnectionSetting = "CosmosDbConnectionString";
+        public const string DatabaseSetting = "%CosmosDbDatabaseId%";
+        public const string ContainerSettingSingleDocument = "%CosmosDbContainerIdSingleDocument%";
+
+        /// <summary>
+        /// Read Through: If the stream does not exist in Redis, refresh it with the values saved in CosmosDB 
+        /// </summary>
+        /// <param name="entry"> The message which has gone through the stream. Includes message id alongside the key/value pairs </param>
+        /// <param name="items"> Container for where the CosmosDB items are stored </param>
+        /// <param name="logger"> ILogger used to write key information </param>
+        /// <returns></returns>
+        [FunctionName(nameof(ReadThroughForStreamSingleDocumentAsync))]
+        public static async Task ReadThroughForStreamSingleDocumentAsync(
+               [RedisPubSubTrigger(RedisConnectionSetting, "__keyevent@0__:keymiss")] string entry,
+               [CosmosDB(
+                    databaseName: DatabaseSetting,
+                    containerName: ContainerSettingSingleDocument,
+                    Connection = CosmosDbConnectionSetting)] CosmosClient cosmosDbClient,
+               ILogger logger)
+        {
+
+            if (entry != StreamNameSingleDocument) return;
+            
+            // Connect CosmosDB container
+            Container cosmosDbContainer = cosmosDbClient.GetContainer(Environment.GetEnvironmentVariable(DatabaseSetting.Replace("%", "")), Environment.GetEnvironmentVariable(ContainerSettingSingleDocument.Replace("%", "")));
+
+            // Query Database by the stream name
+            FeedIterator<StreamDataSingleDocument> query = cosmosDbContainer.GetItemLinqQueryable<StreamDataSingleDocument>(true)
+                .Where(b => b.id == StreamNameSingleDocument)
+                .ToFeedIterator();
+            FeedResponse<StreamDataSingleDocument> response = await query.ReadNextAsync();
+            StreamDataSingleDocument results = response.FirstOrDefault(defaultValue: null);
+
+            // If stream not found
+            if (results == null)
+            {
+                logger.LogWarning("{streamNameSingleDocument} was not found in the database, failed to read stream", StreamNameSingleDocument);
+            }
+            else
+            {
+                logger.LogInformation("{streamNameSingleDocument} was  found in the database", StreamNameSingleDocument);
+
+                // Go through each message and format the key/value pairs
+                foreach (var message in results.messages)
+                {
+                    var values = new NameValueEntry[message.Value.Count];
+                    int i = 0;
+                    foreach (var pair in message.Value)
+                    {
+                        values[i++] = new NameValueEntry(pair.Key, pair.Value);
+                    }
+
+                    // Upload value to Redis Stream
+                    await _redisDB.Value.StreamAddAsync(StreamNameSingleDocument, values, messageId: message.Key, maxLength: results.maxlen);
+                }
+            }         
+        }
+    }
+}

--- a/samples/CosmosDBIntegration/WriteAroundSamples/StreamSample.cs
+++ b/samples/CosmosDBIntegration/WriteAroundSamples/StreamSample.cs
@@ -10,15 +10,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
     internal class StreamSample
     {
         // Redis database and stream stored in local.settings.json
-        public const string redisConnectionSetting = "redisConnectionString";
-        private static readonly Lazy<IDatabaseAsync> redisDB = new Lazy<IDatabaseAsync>(() =>
-           ConnectionMultiplexer.Connect(Environment.GetEnvironmentVariable(redisConnectionSetting)).GetDatabase());
-        public const string stream = "streamTest";
+        public const string RedisConnectionSetting = "RedisConnectionString";
+        private static readonly Lazy<IDatabaseAsync> _redisDB = new Lazy<IDatabaseAsync>(() =>
+           ConnectionMultiplexer.Connect(Environment.GetEnvironmentVariable(RedisConnectionSetting)).GetDatabase());
+        public static string StreamName = Environment.GetEnvironmentVariable("StreamTest");
 
         // CosmosDB connection string, database name and container name stored in local.settings.json
-        public const string cosmosDbConnectionSetting = "cosmosDbConnectionString";
-        public const string databaseSetting = "%cosmosDbDatabaseId%";
-        public const string containerSetting = "%cosmosDbContainerId%";
+        public const string CosmosDbConnectionSetting = "CosmosDbConnectionString";
+        public const string DatabaseSetting = "%CosmosDbDatabaseId%";
+        public const string ContainerSetting = "%CosmosDbContainerId%";
 
         /// <summary>
         /// Write Around: Write from Cosmos DB to Redis whenever a change occurs in one of the CosmosDB documents
@@ -28,27 +28,71 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
         [FunctionName(nameof(WriteAroundForStreamAsync))]
         public static async Task WriteAroundForStreamAsync(
             [CosmosDBTrigger(
-                databaseName: databaseSetting,
-                containerName: containerSetting,
-                Connection = cosmosDbConnectionSetting,
+                databaseName: DatabaseSetting,
+                containerName: ContainerSetting,
+                Connection = CosmosDbConnectionSetting,
                 LeaseContainerName = "leases",
-                CreateLeaseContainerIfNotExists = true)]IReadOnlyList<CosmosDBData> input, ILogger logger)
+                CreateLeaseContainerIfNotExists = true)]IReadOnlyList<StreamData> input, ILogger logger)
         {
-            if (input != null)
+            if (input == null) return;
+
+            // Iterate through each changed document
+            foreach (var document in input)
             {
-                foreach (var document in input)
+                logger.LogInformation("{messageID} changed and sent to {stream} ", document.id, StreamName);
+
+                var values = new NameValueEntry[document.values.Count];
+                int i = 0;
+
+                // Format the key/value pairs
+                foreach (KeyValuePair<string, string> entry in document.values)
                 {
-                    logger.LogInformation(document.id + " changed");
-                    var values = new NameValueEntry[document.values.Count];
+                    values[i++] = new NameValueEntry(entry.Key, entry.Value);
+                }
+
+                // Upload value to Redis Stream
+                await _redisDB.Value.StreamAddAsync(StreamName, values);
+            }     
+        }
+       
+        public const string ContainerSettingSingleDocument = "%CosmosDbContainerIdSingleDocument%";
+        public static string StreamNameSingleDocument = Environment.GetEnvironmentVariable("StreamTestSingleDocument");
+
+        /// <summary>
+        /// Write Around (Single Document): Write from Cosmos DB to Redis whenever a change occurs in one of the CosmosDB documents
+        /// </summary>
+        /// <param name="input"> List of changed documents in CosmosDB </param>
+        /// <param name="logger"> ILogger used to write key information </param>
+        [FunctionName(nameof(CosmosToRedisForStreamSingleDocumentAsync))]
+        public static async Task CosmosToRedisForStreamSingleDocumentAsync(
+            [CosmosDBTrigger(
+                databaseName: DatabaseSetting,
+                containerName: ContainerSettingSingleDocument,
+                Connection = CosmosDbConnectionSetting,
+                LeaseContainerName = "leases",
+                CreateLeaseContainerIfNotExists = true)]IReadOnlyList<StreamDataSingleDocument> input, ILogger logger)
+        {
+            if (input == null) return;
+
+            // Iterate through each changed document
+            foreach (var document in input)
+            {
+                logger.LogInformation("{stream1} changed and sent to {stream2} ", document.id, StreamNameSingleDocument);
+
+                // Go through each message and format the key/value pairs
+                foreach (var message in document.messages)
+                {
+                    var values = new NameValueEntry[message.Value.Count];
                     int i = 0;
-                    foreach (KeyValuePair<string, string> entry in document.values)
+                    foreach (var entry in message.Value)
                     {
                         values[i++] = new NameValueEntry(entry.Key, entry.Value);
                     }
 
-                    await redisDB.Value.StreamAddAsync(stream, values);
+                    // Upload value to Redis Stream
+                    await _redisDB.Value.StreamAddAsync(StreamNameSingleDocument, values, messageId: message.Key, maxLength: document.maxlen);
                 }
-            }
-        }
-     }
+            }  
+        }  
+    }
 }

--- a/samples/CosmosDBIntegration/WriteAroundSamples/WriteAroundSamples.csproj
+++ b/samples/CosmosDBIntegration/WriteAroundSamples/WriteAroundSamples.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.6.122" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs.Extensions.Redis\Microsoft.Azure.WebJobs.Extensions.Redis.csproj" />
     <ProjectReference Include="..\..\dotnet\Microsoft.Azure.WebJobs.Extensions.Redis.Samples.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/CosmosDBIntegration/WriteBehindSamples/StreamSample.cs
+++ b/samples/CosmosDBIntegration/WriteBehindSamples/StreamSample.cs
@@ -1,6 +1,10 @@
-﻿using Microsoft.Azure.WebJobs.Extensions.Redis.Samples.Models;
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
+using Microsoft.Azure.WebJobs.Extensions.Redis.Samples.Models;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
@@ -8,32 +12,77 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
     internal class StreamSample
     {
         // Redis connection string and stream names stored in local.settings.json
-        public const string redisConnectionSetting = "redisConnectionString";
-        public const string streamName = "streamTest";
+        public const string RedisConnectionSetting = "RedisConnectionString";
+        public const string StreamName = "%StreamTest%";
 
         // CosmosDB connection string, client, database name and container name stored in local.settings.json
-        public const string cosmosDbConnectionSetting = "cosmosDbConnectionString";
-        public const string databaseSetting = "%cosmosDbDatabaseId%";
-        public const string containerSetting = "%cosmosDbContainerId%";
+        public const string CosmosDbConnectionSetting = "CosmosDbConnectionString";
+        private static CosmosClient _cosmosDbClient = new(
+            connectionString: Environment.GetEnvironmentVariable(CosmosDbConnectionSetting)!);
+        public const string DatabaseSetting = "%CosmosDbDatabaseId%";
+        public const string ContainerSetting = "%CosmosDbContainerId%";
 
         /// <summary>
-        /// Write behind: Write to CosmosDB asynchronously whenever a new value is added to the Redis Stream
+        /// Write behind: Write messages to CosmosDB asynchronously whenever a new value is added to the Redis Stream. Each message will get it's own document.
         /// </summary>
         /// <param name="entry"> The message which has gone through the stream. Includes message id alongside the key/value pairs </param>
         /// <param name="items"> Container for where the CosmosDB items are stored </param>
         /// <param name="logger"> ILogger used to write key information </param>
         [FunctionName(nameof(WriteBehindForStream))]
         public static async Task WriteBehindForStream(
-                [RedisStreamTrigger(redisConnectionSetting, streamName)] StreamEntry entry,
+                [RedisStreamTrigger(RedisConnectionSetting, StreamName)] StreamEntry entry,
                 [CosmosDB(
-                databaseName: databaseSetting,
-                containerName: containerSetting,
-                Connection = cosmosDbConnectionSetting)]
-                IAsyncCollector<CosmosDBData> items,
+                    databaseName: DatabaseSetting,
+                    containerName: ContainerSetting,
+                    Connection = CosmosDbConnectionSetting)] IAsyncCollector<StreamData> items,
                 ILogger logger)
         {
             // Insert data into CosmosDB asynchronously
-            await items.AddAsync(CosmosDBData.Format(entry, logger));
+            await items.AddAsync(StreamData.Format(entry, logger));
+        }
+
+        public const string ContainerSettingSingleDocument = "%CosmosDbContainerIdSingleDocument%";
+
+        /// <summary>
+        /// Write behind (Single Document): Write messages to a single document in CosmosDB asynchronously whenever a new value is added to the Redis Stream.
+        /// </summary>
+        /// <param name="entry"> The message which has gone through the stream. Includes message id alongside the key/value pairs </param>
+        /// <param name="items"> Container for where the CosmosDB items are stored </param>
+        /// <param name="logger"> ILogger used to write key information </param>
+        [FunctionName(nameof(WriteBehindForStreamSingleDocumentAsync))]
+        public static async Task WriteBehindForStreamSingleDocumentAsync(
+                [RedisStreamTrigger(RedisConnectionSetting, StreamName)] StreamEntry entry,
+                [CosmosDB(
+                    databaseName: DatabaseSetting,
+                    containerName: ContainerSettingSingleDocument,
+                    Connection = CosmosDbConnectionSetting)] IAsyncCollector<StreamDataSingleDocument> items,
+                 ILogger logger)
+        {
+            string stream = Environment.GetEnvironmentVariable(StreamName.Replace("%", ""));
+
+            // Connect CosmosDB container
+            Container cosmosDbContainer = _cosmosDbClient.GetContainer(Environment.GetEnvironmentVariable(DatabaseSetting.Replace("%", "")), Environment.GetEnvironmentVariable(ContainerSettingSingleDocument.Replace("%", "")));
+
+            // Query CosmosDB database by the stream name
+            FeedIterator<StreamDataSingleDocument> query = cosmosDbContainer.GetItemLinqQueryable<StreamDataSingleDocument>(true)
+                    .Where(b => b.id == stream)
+                    .ToFeedIterator();
+
+            FeedResponse<StreamDataSingleDocument> response = await query.ReadNextAsync();
+            StreamDataSingleDocument results = response.FirstOrDefault(defaultValue: null);       
+
+            if (results == null)
+            {
+                // If the stream does not exist in CosmosDB, create a new entry and insert into CosmosDB asynchronously
+                StreamDataSingleDocument data = StreamDataSingleDocument.CreateNewEntry(entry, stream, logger);
+                await items.AddAsync(data);
+            }
+            else
+            {
+                // If the stream exists in CosmosDB, add to the existing entry and insert into CosmosDB asynchronously
+                StreamDataSingleDocument data = StreamDataSingleDocument.UpdateExistingEntry(results, entry, logger);
+                await items.AddAsync(data);
+            }
         }
     }
 }

--- a/samples/CosmosDBIntegration/WriteBehindSamples/WriteBehindSamples.csproj
+++ b/samples/CosmosDBIntegration/WriteBehindSamples/WriteBehindSamples.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.Azure.Functions.Worker.Extensions.Redis\Microsoft.Azure.Functions.Worker.Extensions.Redis.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs.Extensions.Redis\Microsoft.Azure.WebJobs.Extensions.Redis.csproj" />
     <ProjectReference Include="..\..\dotnet\Microsoft.Azure.WebJobs.Extensions.Redis.Samples.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/CosmosDBIntegration/WriteThroughSamples/StreamSample.cs
+++ b/samples/CosmosDBIntegration/WriteThroughSamples/StreamSample.cs
@@ -1,38 +1,84 @@
-﻿using Microsoft.Azure.WebJobs.Extensions.Redis.Samples.Models;
+﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.WebJobs.Extensions.Redis.Samples.Models;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
+using System;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
 {
     internal class StreamSample
     {
         // Redis connection string and stream names stored in local.settings.json
-        public const string redisConnectionSetting = "redisConnectionString";
-        public const string streamName = "streamTest";
+        public const string RedisConnectionSetting = "RedisConnectionString";
+        public const string StreamName = "%StreamTest%";
 
-        // CosmosDB connection string, database name and container name stored in local.settings.json
-        public const string cosmosDbConnectionSetting = "cosmosDbConnectionString";
-        public const string databaseSetting = "%cosmosDbDatabaseId%";
-        public const string containerSetting = "%cosmosDbContainerId%";
+        // CosmosDB connection string, client, database name and container name stored in local.settings.json
+        public const string CosmosDbConnectionSetting = "CosmosDbConnectionString";
+        private static CosmosClient _cosmosDbClient = new(
+            connectionString: Environment.GetEnvironmentVariable(CosmosDbConnectionSetting)!);
+        public const string DatabaseSetting = "%CosmosDbDatabaseId%";
+        public const string ContainerSetting = "%CosmosDbContainerId%";
 
         /// <summary>
-        /// Write through: Write to CosmosDB synchronously whenever a new value is added to the Redis Stream
+        /// Write through: Write messages to CosmosDB synchronously whenever a new value is added to the Redis Stream. Each message will get it's own document.
         /// </summary>
         /// <param name="entry"> The message which has gone through the stream. Includes message id alongside the key/value pairs </param>
         /// <param name="items"> Container for where the CosmosDB items are stored </param>
         /// <param name="logger"> ILogger used to write key information </param>
         [FunctionName(nameof(WriteThroughForStream))]
         public static void WriteThroughForStream(
-                [RedisStreamTrigger(redisConnectionSetting, streamName)] StreamEntry entry,
-                 [CosmosDB(
-                databaseName: databaseSetting,
-                containerName: containerSetting,
-                Connection = cosmosDbConnectionSetting)]
-                ICollector<CosmosDBData> items,
+                [RedisStreamTrigger(RedisConnectionSetting, StreamName)] StreamEntry entry,
+                [CosmosDB(
+                    databaseName: DatabaseSetting,
+                    containerName: ContainerSetting,               
+                    Connection = CosmosDbConnectionSetting)] ICollector<StreamData> items,
                 ILogger logger)
         {
             // Insert data into CosmosDB synchronously
-            items.Add(CosmosDBData.Format(entry, logger));
+            items.Add(StreamData.Format(entry, logger));
+        }
+
+        public const string ContainerSettingSingleDocument = "%CosmosDbContainerIdSingleDocument%";
+
+        /// <summary>
+        /// Write through (Single Document): Write messages to a single document in CosmosDB synchronously whenever a new value is added to the Redis Stream.
+        /// </summary>
+        /// <param name="entry"> The message which has gone through the stream. Includes message id alongside the key/value pairs </param>
+        /// <param name="items"> Container for where the CosmosDB items are stored </param>
+        /// <param name="logger"> ILogger used to write key information </param>
+        [FunctionName(nameof(WriteThroughForStreamSingleDocument))]
+        public static void WriteThroughForStreamSingleDocument(
+                [RedisStreamTrigger(RedisConnectionSetting, StreamName)] StreamEntry entry,
+                [CosmosDB(
+                    databaseName: DatabaseSetting,
+                    containerName: ContainerSettingSingleDocument,
+                    Connection = CosmosDbConnectionSetting)] ICollector<StreamDataSingleDocument> items,
+                 ILogger logger)
+        {
+            string stream = Environment.GetEnvironmentVariable(StreamName.Replace("%", ""));
+
+            // Connect CosmosDB container
+            Container cosmosDbContainer = _cosmosDbClient.GetContainer(Environment.GetEnvironmentVariable(DatabaseSetting.Replace("%", "")), Environment.GetEnvironmentVariable(ContainerSettingSingleDocument.Replace("%", "")));
+
+            // Query CosmosDB database by the stream name
+            StreamDataSingleDocument results = cosmosDbContainer.GetItemLinqQueryable<StreamDataSingleDocument>(true)
+                    .Where(b => b.id == stream)
+                    .AsEnumerable()
+                    .FirstOrDefault();
+
+            if (results == null)
+            {
+                // If the stream does not exist in CosmosDB, create a new entry and insert into CosmosDB synchronously
+                StreamDataSingleDocument data = StreamDataSingleDocument.CreateNewEntry(entry, stream, logger);
+                items.Add(data);
+            }
+            else
+            {
+                // If the stream exists in CosmosDB, add to the existing entry and insert into CosmosDB synchronously
+                StreamDataSingleDocument data = StreamDataSingleDocument.UpdateExistingEntry(results, entry, logger);
+                items.Add(data);
+            }
         }
     }
 }

--- a/samples/CosmosDBIntegration/WriteThroughSamples/WriteThroughSamples.csproj
+++ b/samples/CosmosDBIntegration/WriteThroughSamples/WriteThroughSamples.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.Azure.Functions.Worker.Extensions.Redis\Microsoft.Azure.Functions.Worker.Extensions.Redis.csproj" />
+    <ProjectReference Include="..\..\..\src\Microsoft.Azure.WebJobs.Extensions.Redis\Microsoft.Azure.WebJobs.Extensions.Redis.csproj" />
     <ProjectReference Include="..\..\dotnet\Microsoft.Azure.WebJobs.Extensions.Redis.Samples.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Created sample functions for Redis and CosmosDB synchronization using streams following a write through, write behind, write around and read through caching pattern. 

Read through: Triggers when a request is sent to a stream that no longer exists in Redis. It searches for the stream in CosmosDB and rehydrates the missing stream.

Write around: Triggers whenever a change is made on a document in CosmosDB. It re-writes the entire document from CosmosDB to a new stream in Redis.

Write Behind: Triggers whenever a message is added to the Redis stream. Writes the message asynchronously to a CosmosDB database. Messages are either written on a single document that will be constantly updated or separately on different documents. 

Write Through: Workes similarly to the Write Behind trigger except it writes messages synchronously. 