### PR TITLE
Redis output bindings

### DIFF
--- a/samples/dotnet/RedisSamples.cs
+++ b/samples/dotnet/RedisSamples.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
             ILogger logger)
         {
             logger.LogInformation(message);
-            return new string[] { "keyspaceTest", message };
+            return new string[] { nameof(OutputBindingArgumentsOnly), message };
         }
 
         [FunctionName(nameof(PubSubTriggerResolvedChannel))]

--- a/samples/dotnet/RedisSamples.cs
+++ b/samples/dotnet/RedisSamples.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using StackExchange.Redis;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
 {
@@ -13,6 +15,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
             ILogger logger)
         {
             logger.LogInformation(message);
+        }
+
+        [FunctionName(nameof(OutputBindingArgumentsOnly))]
+        [return: Redis(localhostSetting, "set")]
+        public static string[] OutputBindingArgumentsOnly(
+            [RedisPubSubTrigger(localhostSetting, "pubsubTest")] string message,
+            ILogger logger)
+        {
+            logger.LogInformation(message);
+            return new string[] { "keyspaceTest", message };
+        }
+
+        [FunctionName(nameof(OutputBindingCommandAndArguments))]
+        [return: Redis(localhostSetting)]
+        public static string[] OutputBindingCommandAndArguments(
+            [RedisPubSubTrigger(localhostSetting, "pubsubTest")] string message,
+            ILogger logger)
+        {
+            logger.LogInformation(message);
+            return new string[] { "set", "keyspaceTest", message };
         }
 
         [FunctionName(nameof(PubSubTriggerResolvedChannel))]
@@ -53,6 +75,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
             ILogger logger)
         {
             logger.LogInformation(entry);
+        }
+
+        [FunctionName(nameof(StreamTriggerDeleteEntry))]
+        public static void StreamTriggerDeleteEntry(
+            [RedisStreamTrigger(localhostSetting, "streamTest2")] StreamEntry entry,
+            [Redis(localhostSetting, "XDEL")] out string[] result,
+            ILogger logger)
+        {
+            logger.LogInformation($"Stream entry from key 'streamTest2' with Id '{entry.Id}' and values '{JsonConvert.SerializeObject(entry.Values.ToDictionary(x => x.Name.ToString(), x => x.Value.ToString()))}");
+            result = new string[] { "streamTest2", entry.Id.ToString() };
         }
     }
 }

--- a/samples/dotnet/RedisSamples.cs
+++ b/samples/dotnet/RedisSamples.cs
@@ -18,23 +18,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
         }
 
         [FunctionName(nameof(OutputBindingArgumentsOnly))]
-        [return: Redis(localhostSetting, "set")]
+        [return: Redis(localhostSetting, "SET")]
         public static string[] OutputBindingArgumentsOnly(
             [RedisPubSubTrigger(localhostSetting, "pubsubTest")] string message,
             ILogger logger)
         {
             logger.LogInformation(message);
             return new string[] { "keyspaceTest", message };
-        }
-
-        [FunctionName(nameof(OutputBindingCommandAndArguments))]
-        [return: Redis(localhostSetting)]
-        public static string[] OutputBindingCommandAndArguments(
-            [RedisPubSubTrigger(localhostSetting, "pubsubTest")] string message,
-            ILogger logger)
-        {
-            logger.LogInformation(message);
-            return new string[] { "set", "keyspaceTest", message };
         }
 
         [FunctionName(nameof(PubSubTriggerResolvedChannel))]
@@ -83,7 +73,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
             [Redis(localhostSetting, "XDEL")] out string[] result,
             ILogger logger)
         {
-            logger.LogInformation($"Stream entry from key 'streamTest2' with Id '{entry.Id}' and values '{JsonConvert.SerializeObject(entry.Values.ToDictionary(x => x.Name.ToString(), x => x.Value.ToString()))}");
+            logger.LogInformation($"Stream entry from key 'streamTest2' with Id '{entry.Id}' and values '" +
+                JsonConvert.SerializeObject(entry.Values.ToDictionary(x => x.Name.ToString(), x => x.Value.ToString())));
             result = new string[] { "streamTest2", entry.Id.ToString() };
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
@@ -10,24 +10,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         private readonly IConnectionMultiplexer multiplexer;
         private readonly string command;
         private readonly ILogger logger;
-
-        private IBatch batch;
+        private readonly IBatch batch;
 
         public RedisAsyncCollector(IConnectionMultiplexer multiplexer, string command, ILogger logger)
         {
             this.multiplexer = multiplexer;
             this.command = command;
             this.logger = logger;
+            this.batch = multiplexer.GetDatabase().CreateBatch();
         }
 
         public Task AddAsync(string[] arguments, CancellationToken cancellationToken = default)
         {
-            if (batch is null)
-            {
-                logger?.LogDebug("Creating batch.");
-                batch = multiplexer.GetDatabase().CreateBatch();
-            }
-
             logger?.LogDebug($"Adding {command} command to batch with input string[] arguments.");
             _ = batch.ExecuteAsync(command, arguments, CommandFlags.FireAndForget);
             return Task.CompletedTask;
@@ -37,7 +31,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         {
             logger?.LogDebug("Executing batch.");
             batch.Execute();
-            batch = null;
             return Task.CompletedTask;
         }
     }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         {
             if (transaction is null)
             {
+                logger?.LogDebug("Creating transaction.");
                 transaction = multiplexer.GetDatabase().CreateTransaction();
             }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis
+{
+    internal class RedisAsyncCollector : IAsyncCollector<string[]>
+    {
+        private readonly IConnectionMultiplexer multiplexer;
+        private readonly string attributeCommand;
+        private readonly ILogger logger;
+
+        private ITransaction transaction;
+
+        public RedisAsyncCollector(IConnectionMultiplexer multiplexer, string attributeCommand, ILogger logger)
+        {
+            this.multiplexer = multiplexer;
+            this.attributeCommand = attributeCommand;
+            this.logger = logger;
+        }
+
+        public Task AddAsync(string[] arguments, CancellationToken cancellationToken = default)
+        {
+            if (transaction is null)
+            {
+                transaction = multiplexer.GetDatabase().CreateTransaction();
+            }
+
+            if (string.IsNullOrWhiteSpace(attributeCommand) && arguments.Length > 1)
+            {
+                logger?.LogDebug($"Adding command to transaction using only input string[] arguments.");
+                _ = transaction.ExecuteAsync(arguments[0], new ArraySegment<string>(arguments, 1, arguments.Length - 1));
+            }
+            else
+            {
+                logger?.LogDebug($"Adding command to transaction using given command with input string[] arguments.");
+                _ = transaction.ExecuteAsync(attributeCommand, arguments);
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task AddAsync(byte[][] arguments, CancellationToken cancellationToken = default)
+        {
+            if (transaction is null)
+            {
+                transaction = multiplexer.GetDatabase().CreateTransaction();
+            }
+
+            logger?.LogDebug($"Adding command to transaction using given command with input byte[][] arguments.");
+            _ = transaction.ExecuteAsync(attributeCommand, arguments);
+
+            return Task.CompletedTask;
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken = default)
+        {
+            logger?.LogDebug("Executing transaction.");
+            bool result = transaction.Execute();
+            transaction = null;
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             }
 
             logger?.LogDebug($"Adding {command} command to transaction with input string[] arguments.");
-            _ = transaction.ExecuteAsync(command, arguments);
+            _ = transaction.ExecuteAsync(command, arguments, CommandFlags.FireAndForget);
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAttribute.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.Azure.WebJobs.Description;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis
+{
+    /// <summary>
+    /// An output binding that excutes a command on the redis instances.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.ReturnValue)]
+    [Binding]
+    public sealed class RedisAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new <see cref="RedisAttribute"/>.
+        /// </summary>
+        /// <param name="connectionStringSetting">Redis connection string setting.</param>
+        /// <param name="command">The command to be executed on the cache.</param>
+        public RedisAttribute(string connectionStringSetting, string command = "")
+        {
+            ConnectionStringSetting = connectionStringSetting;
+            Command = command;
+        }
+
+        /// <summary>
+        /// Gets or sets the Redis connection string.
+        /// </summary>
+        [AutoResolve]
+        public string ConnectionStringSetting { get; }
+
+        /// <summary>
+        /// The command to be executed on the cache.
+        /// </summary>
+        [AutoResolve]
+        public string Command { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
@@ -31,8 +31,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             this.configuration = configuration;
             this.nameResolver = nameResolver;
             this.loggerFactory = loggerFactory;
-
-            
         }
 
         /// <summary>
@@ -55,8 +53,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             FluentBindingRule<RedisStreamTriggerAttribute> streamTriggerRule = context.AddBindingRule<RedisStreamTriggerAttribute>();
             streamTriggerRule.BindToTrigger(new RedisStreamTriggerBindingProvider(configuration, nameResolver, loggerFactory.CreateLogger("RedisStreamTrigger")));
 
-            FluentBindingRule<RedisAttribute> bindingRule = context.AddBindingRule<RedisAttribute>();
-            bindingRule.BindToCollector((attr) => new RedisAsyncCollector(GetOrCreateConnectionMultiplexer(attr), attr.Command, loggerFactory.CreateLogger("RedisOutputBinding")));
+            FluentBindingRule<RedisAttribute> outputBindingRule = context.AddBindingRule<RedisAttribute>();
+            outputBindingRule.BindToCollector((attr) => new RedisAsyncCollector(GetOrCreateConnectionMultiplexer(attr), attr.Command, loggerFactory.CreateLogger("RedisOutputBinding")));
 #pragma warning restore CS0618
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis
 {
@@ -14,9 +14,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     [Extension("Redis")]
     public class RedisExtensionConfigProvider : IExtensionConfigProvider
     {
-        private readonly IConfiguration configuration;
-        private readonly INameResolver nameResolver;
-        private readonly ILoggerFactory loggerFactory;
+        internal readonly IConfiguration configuration;
+        internal readonly INameResolver nameResolver;
+        internal readonly ILoggerFactory loggerFactory;
+
+        private static readonly ConcurrentDictionary<string, IConnectionMultiplexer> connectionMultiplexerCache = new ConcurrentDictionary<string, IConnectionMultiplexer>();
 
         /// <summary>
         /// Adds Redis triggers and bindings to the extension context.
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             this.configuration = configuration;
             this.nameResolver = nameResolver;
             this.loggerFactory = loggerFactory;
+
+            
         }
 
         /// <summary>
@@ -50,7 +54,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
             FluentBindingRule<RedisStreamTriggerAttribute> streamTriggerRule = context.AddBindingRule<RedisStreamTriggerAttribute>();
             streamTriggerRule.BindToTrigger(new RedisStreamTriggerBindingProvider(configuration, nameResolver, loggerFactory.CreateLogger("RedisStreamTrigger")));
+
+            FluentBindingRule<RedisAttribute> bindingRule = context.AddBindingRule<RedisAttribute>();
+            bindingRule.BindToCollector((attr) => new RedisAsyncCollector(GetOrCreateConnectionMultiplexer(attr), attr.Command, loggerFactory.CreateLogger("RedisOutputBinding")));
 #pragma warning restore CS0618
+        }
+
+        internal IConnectionMultiplexer GetOrCreateConnectionMultiplexer(RedisAttribute attribute)
+        {
+            string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
+            return connectionMultiplexerCache.GetOrAdd(connectionString, (string cs) => ConnectionMultiplexer.Connect(cs));
         }
     }
 }

--- a/test/dotnet/Integration/RedisOutputBindingTestFunctions.cs
+++ b/test/dotnet/Integration/RedisOutputBindingTestFunctions.cs
@@ -30,5 +30,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             logger.LogInformation($"Stream entry from key '{nameof(StreamTriggerDeleter)}' with Id '{entry.Id}' and values '{JsonConvert.SerializeObject(entry.Values.ToDictionary(x => x.Name.ToString(), x => x.Value.ToString()))}");
             arguments = new string[] { nameof(StreamTriggerDeleter), entry.Id.ToString() };
         }
+
+
+        [FunctionName(nameof(MultipleAddAsyncCalls))]
+        public static void MultipleAddAsyncCalls(
+            [RedisPubSubTrigger(localhostSetting, nameof(MultipleAddAsyncCalls))] string entry,
+            [Redis(localhostSetting, "SET")] IAsyncCollector<string[]> collector,
+            ILogger logger)
+        {
+            string[] keys = entry.Split(',');
+            foreach (string key in keys)
+            {
+                collector.AddAsync(new string[] { key, nameof(MultipleAddAsyncCalls) });
+            }
+        }
     }
 }

--- a/test/dotnet/Integration/RedisOutputBindingTestFunctions.cs
+++ b/test/dotnet/Integration/RedisOutputBindingTestFunctions.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
+{
+    public static class RedisOutputBindingTestFunctions
+    {
+        public const string localhostSetting = "redisLocalhost";
+        public const string keyeventChannelSet = "__keyevent@0__:set";
+        public const int pollingInterval = 100;
+
+        [FunctionName(nameof(SetDeleter))]
+        public static void SetDeleter(
+            [RedisPubSubTrigger(localhostSetting, keyeventChannelSet)] string key,
+            [Redis(localhostSetting, "DEL")] out string[] arguments,
+            ILogger logger)
+        {
+            logger.LogInformation($"Deleting recently SET key '{key}'");
+            arguments = new string[] { key };
+        }
+
+        [FunctionName(nameof(StreamTriggerDeleter))]
+        public static void StreamTriggerDeleter(
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTriggerDeleter), pollingIntervalInMs: pollingInterval)] StreamEntry entry,
+            [Redis(localhostSetting, "XDEL")] out string[] arguments,
+            ILogger logger)
+        {
+            logger.LogInformation($"Stream entry from key '{nameof(StreamTriggerDeleter)}' with Id '{entry.Id}' and values '{JsonConvert.SerializeObject(entry.Values.ToDictionary(x => x.Name.ToString(), x => x.Value.ToString()))}");
+            arguments = new string[] { nameof(StreamTriggerDeleter), entry.Id.ToString() };
+        }
+    }
+}

--- a/test/dotnet/Integration/RedisOutputBindingTestFunctions.cs
+++ b/test/dotnet/Integration/RedisOutputBindingTestFunctions.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             string[] keys = entry.Split(',');
             foreach (string key in keys)
             {
-                collector.AddAsync(new string[] { key, nameof(MultipleAddAsyncCalls) });
+                collector.AddAsync(new string[] { key, nameof(MultipleAddAsyncCalls) }).Wait();
             }
         }
     }

--- a/test/dotnet/Integration/RedisOutputBindingTests.cs
+++ b/test/dotnet/Integration/RedisOutputBindingTests.cs
@@ -1,0 +1,80 @@
+﻿using StackExchange.Redis;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
+{
+    [Collection("RedisTriggerTests")]
+    public class RedisOutputBindingTests
+    {
+        [Fact]
+        public async void SetDeleter_SuccessfullyDeletes()
+        {
+            string functionName = nameof(RedisOutputBindingTestFunctions.SetDeleter);
+            ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();
+            counts.TryAdd($"Executed '{functionName}' (Succeeded", 1);
+
+            bool exists = true;
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            {
+                using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+                {
+                    functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+
+                    await multiplexer.GetDatabase().StringSetAsync(functionName, "test");
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    exists = await multiplexer.GetDatabase().KeyExistsAsync(functionName);
+                    await multiplexer.CloseAsync();
+                    functionsProcess.Kill();
+                };
+                var incorrect = counts.Where(pair => pair.Value != 0);
+                Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
+                Assert.False(exists);
+            }
+        }
+
+        [Fact]
+        public async void StreamTriggerDeleter_SuccessfullyDeletes()
+        {
+            string functionName = nameof(RedisOutputBindingTestFunctions.StreamTriggerDeleter);
+            ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();
+            counts.TryAdd($"Executed '{functionName}' (Succeeded", 1);
+
+            string[] namesArray = new string[] { "a", "c" };
+            string[] valuesArray = new string[] { "b", "d" };
+
+            NameValueEntry[] nameValueEntries = new NameValueEntry[namesArray.Length];
+            for (int i = 0; i < namesArray.Length; i++)
+            {
+                nameValueEntries[i] = new NameValueEntry(namesArray[i], valuesArray[i]);
+            }
+
+            long length = 1;
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            {
+                using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+                {
+                    functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+
+                    await multiplexer.GetDatabase().StreamAddAsync(functionName, nameValueEntries);
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    length = await multiplexer.GetDatabase().StreamLengthAsync(functionName);
+                    await multiplexer.CloseAsync();
+                    functionsProcess.Kill();
+                };
+                var incorrect = counts.Where(pair => pair.Value != 0);
+                Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
+                Assert.Equal(0, length);
+            }
+        }
+    }
+}

--- a/test/dotnet/Integration/RedisOutputBindingTests.cs
+++ b/test/dotnet/Integration/RedisOutputBindingTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         }
 
         [Fact]
-        public async void MultipleAddAsyncCalls_SuccessfullyUsesOneTransaction()
+        public async void MultipleAddAsyncCalls_SuccessfullyFlushes()
         {
             string functionName = nameof(RedisOutputBindingTestFunctions.MultipleAddAsyncCalls);
             ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();


### PR DESCRIPTION
These bindings allow functions to run commands on Redis after the function has ended. The binding uses pipelining to batch operations. Each call to `AddAsync` adds an operation to the batch, and `FlushAsync` sends all commands in the batch to Redis.