### PR TITLE
Input Bindings

### DIFF
--- a/samples/dotnet/RedisSamples.cs
+++ b/samples/dotnet/RedisSamples.cs
@@ -51,6 +51,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
             logger.LogInformation(message);
         }
 
+        [FunctionName(nameof(SetGetter))]
+        public static void SetGetter(
+            [RedisPubSubTrigger(localhostSetting, "__keyevent@0__:set")] string message,
+            [Redis(localhostSetting, "GET {Message}")] string value,
+            ILogger logger)
+        {
+            logger.LogInformation($"Key '{message}' was set to value '{value}'");
+        }
+
         [FunctionName(nameof(ListTrigger))]
         public static void ListTrigger(
             [RedisListTrigger(localhostSetting, "listTest")] string entry,

--- a/samples/dotnet/RedisSamples.cs
+++ b/samples/dotnet/RedisSamples.cs
@@ -53,11 +53,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Samples
 
         [FunctionName(nameof(SetGetter))]
         public static void SetGetter(
-            [RedisPubSubTrigger(localhostSetting, "__keyevent@0__:set")] string message,
+            [RedisPubSubTrigger(localhostSetting, "__keyevent@0__:set")] string key,
             [Redis(localhostSetting, "GET {Message}")] string value,
             ILogger logger)
         {
-            logger.LogInformation($"Key '{message}' was set to value '{value}'");
+            logger.LogInformation($"Key '{key}' was set to value '{value}'");
         }
 
         [FunctionName(nameof(ListTrigger))]

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisAttribute.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         }
 
         /// <summary>
-        /// Gets or sets the Redis connection string.
+        /// Redis connection string setting.
+        /// This setting will be used to resolve the actual connection string from the appsettings.
         /// </summary>
         public string ConnectionStringSetting { get; }
 

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisAttribute.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
+
+namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
+{
+    /// <summary>
+    /// An output binding that excutes a command on the redis instances.
+    /// </summary>
+    public sealed class RedisAttribute : BindingAttribute
+    {
+        /// <summary>
+        /// Initializes a new <see cref="RedisAttribute"/>.
+        /// </summary>
+        /// <param name="connectionStringSetting">Redis connection string setting.</param>
+        /// <param name="command">The command to be executed on the cache.</param>
+        public RedisAttribute(string connectionStringSetting, string command)
+        {
+            ConnectionStringSetting = connectionStringSetting;
+            Command = command;
+        }
+
+        /// <summary>
+        /// Gets or sets the Redis connection string.
+        /// </summary>
+        public string ConnectionStringSetting { get; }
+
+        /// <summary>
+        /// The command to be executed on the cache.
+        /// </summary>
+        public string Command { get; }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
@@ -7,14 +7,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 {
     internal class RedisAsyncCollector : IAsyncCollector<string[]>
     {
-        private readonly IConnectionMultiplexer multiplexer;
         private readonly string command;
         private readonly ILogger logger;
         private readonly IBatch batch;
 
         public RedisAsyncCollector(IConnectionMultiplexer multiplexer, string command, ILogger logger)
         {
-            this.multiplexer = multiplexer;
             this.command = command;
             this.logger = logger;
             this.batch = multiplexer.GetDatabase().CreateBatch();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// </summary>
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="command">The command to be executed on the cache.</param>
-        public RedisAttribute(string connectionStringSetting, string command = "")
+        public RedisAttribute(string connectionStringSetting, string command)
         {
             ConnectionStringSetting = connectionStringSetting;
             Command = command;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAttribute.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         }
 
         /// <summary>
-        /// Gets or sets the Redis connection string.
+        /// Redis connection string setting.
+        /// This setting will be used to resolve the actual connection string from the appsettings.
         /// </summary>
         [AutoResolve]
         public string ConnectionStringSetting { get; }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisConverter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis
+{
+    internal class RedisConverter<T> : IAsyncConverter<RedisAttribute, T>
+    {
+        private readonly IConfiguration configuration;
+        private readonly INameResolver nameResolver;
+        private readonly ILogger logger;
+
+        public RedisConverter(IConfiguration configuration, INameResolver nameResolver, ILogger logger)
+        {
+            this.configuration = configuration;
+            this.nameResolver = nameResolver;
+            this.logger = logger;
+        }
+
+        public async Task<T> ConvertAsync(RedisAttribute input, CancellationToken cancellationToken)
+        {
+            string command = RedisUtilities.ResolveString(nameResolver, input.Command, nameof(input.Command));
+            IDatabase db = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, input.ConnectionStringSetting).GetDatabase();
+
+            string[] arguments = command.Split(' ');
+            switch (arguments[0])
+            {
+                case "GET": return await GET(db, arguments);
+                case "HGET": return await HGET(db, arguments);
+                default:
+                    throw new ArgumentException($"Command '{arguments[0]}' not supported for Redis Input Binding.");
+            }
+        }
+
+        private async Task<T> GET(IDatabase db, string[] arguments)
+        {
+            if (arguments.Length != 2)
+            {
+                throw new ArgumentException($"Command '{arguments[0]}' requires 1 argument.");
+            }
+            RedisValue value = await db.StringGetAsync(arguments[1]);
+            return (T)RedisUtilities.RedisValueTypeConverter(value, typeof(T));
+        }
+
+        private async Task<T> HGET(IDatabase db, string[] arguments)
+        {
+            if (arguments.Length != 3)
+            {
+                throw new ArgumentException($"Command '{arguments[0]}' requires 2 arguments.");
+            }
+            RedisValue value = await db.HashGetAsync(arguments[1], arguments[2]);
+            return (T)RedisUtilities.RedisValueTypeConverter(value, typeof(T));
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 #pragma warning restore CS0618
         }
 
-        public static IConnectionMultiplexer GetOrCreateConnectionMultiplexer(IConfiguration configuration, string connectionStringSetting)
+        internal static IConnectionMultiplexer GetOrCreateConnectionMultiplexer(IConfiguration configuration, string connectionStringSetting)
         {
             string connectionString = RedisUtilities.ResolveConnectionString(configuration, connectionStringSetting);
             return connectionMultiplexerCache.GetOrAdd(connectionString, (string cs) => ConnectionMultiplexer.Connect(cs));

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
@@ -54,11 +54,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             FluentBindingRule<RedisStreamTriggerAttribute> streamTriggerRule = context.AddBindingRule<RedisStreamTriggerAttribute>();
             streamTriggerRule.BindToTrigger(new RedisStreamTriggerBindingProvider(configuration, nameResolver, loggerFactory.CreateLogger("RedisStreamTrigger")));
 
-            FluentBindingRule<RedisAttribute> outputBindingRule = context.AddBindingRule<RedisAttribute>();
-            outputBindingRule.BindToCollector((attr) => new RedisAsyncCollector(GetOrCreateConnectionMultiplexer(configuration, attr.ConnectionStringSetting), attr.Command, loggerFactory.CreateLogger("RedisOutputBinding")));
-
-            FluentBindingRule<RedisAttribute> inputBindingRule = context.AddBindingRule<RedisAttribute>();
-            inputBindingRule.BindToInput<OpenType>(typeof(RedisConverter<>), configuration, nameResolver, loggerFactory.CreateLogger("RedisInputBinding"));
+            FluentBindingRule<RedisAttribute> bindingRule = context.AddBindingRule<RedisAttribute>();
+            bindingRule.BindToCollector((attr) => new RedisAsyncCollector(GetOrCreateConnectionMultiplexer(configuration, attr.ConnectionStringSetting), attr.Command, loggerFactory.CreateLogger("RedisOutputBinding")));
+            bindingRule.BindToInput<OpenType>(typeof(RedisConverter<>), configuration, nameResolver, loggerFactory.CreateLogger("RedisInputBinding"));
 #pragma warning restore CS0618
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisUtilities.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisUtilities.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis
 {
-    public static class RedisUtilities
+    internal static class RedisUtilities
     {
         public static Version Version62 = new Version("6.2");
         public static Version Version70 = new Version("7.0");

--- a/test/dotnet/Integration/RedisInputBindingTestFunctions.cs
+++ b/test/dotnet/Integration/RedisInputBindingTestFunctions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 {
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             [Redis(localhostSetting, $"GET {nameof(GetTester)}")] string value,
             ILogger logger)
         {
-            logger.LogInformation($"Value of key '{nameof(GetTester)}' is currently '{value}'");
+            logger.LogInformation($"Value of key '{nameof(GetTester)}' is currently a type {value.GetType()}: '{value}'");
         }
 
         [FunctionName(nameof(HgetTester))]
@@ -22,6 +23,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             ILogger logger)
         {
             logger.LogInformation($"Value of field 'field' in hash '{nameof(HgetTester)}' is currently '{value}'");
+        }
+
+        [FunctionName(nameof(GetTester_Custom))]
+        public static void GetTester_Custom(
+            [RedisPubSubTrigger(localhostSetting,nameof(GetTester_Custom))] string message,
+            [Redis(localhostSetting, $"GET {nameof(GetTester_Custom)}")] CustomType value,
+            ILogger logger)
+        {
+            logger.LogInformation($"Value of key '{nameof(GetTester_Custom)}' is currently a type {value.GetType()}: '{JsonConvert.SerializeObject(value)}'");
         }
     }
 }

--- a/test/dotnet/Integration/RedisInputBindingTestFunctions.cs
+++ b/test/dotnet/Integration/RedisInputBindingTestFunctions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
+{
+    public static class RedisInputBindingTestFunctions
+    {
+        public const string localhostSetting = "redisLocalhost";
+
+        [FunctionName(nameof(GetTester))]
+        public static void GetTester(
+            [RedisPubSubTrigger(localhostSetting, nameof(GetTester))] string message,
+            [Redis(localhostSetting, $"GET {nameof(GetTester)}")] string value,
+            ILogger logger)
+        {
+            logger.LogInformation($"Value of key '{nameof(GetTester)}' is currently '{value}'");
+        }
+
+        [FunctionName(nameof(HgetTester))]
+        public static void HgetTester(
+            [RedisPubSubTrigger(localhostSetting, nameof(HgetTester))] string message,
+            [Redis(localhostSetting, $"HGET {nameof(HgetTester)} field")] string value,
+            ILogger logger)
+        {
+            logger.LogInformation($"Value of field 'field' in hash '{nameof(HgetTester)}' is currently '{value}'");
+        }
+    }
+}

--- a/test/dotnet/Integration/RedisInputBindingTests.cs
+++ b/test/dotnet/Integration/RedisInputBindingTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             string value = "value";
             ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();
             counts.TryAdd($"Executed '{functionName}' (Succeeded", 1);
-            counts.TryAdd($"Value of key '{functionName}' is currently '{value}'", 1);
+            counts.TryAdd($"Value of key '{functionName}' is currently a type {value.GetType()}: '{value}'", 1);
 
             using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
             {
@@ -68,6 +68,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
                 var incorrect = counts.Where(pair => pair.Value != 0);
                 Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
             }
+        }
+
+        [Fact]
+        public async void GetCustom_SuccessfullyConvertsType()
+        {
+            string functionName = nameof(RedisInputBindingTestFunctions.GetTester_Custom);
+            CustomType value = new CustomType { Field = "a", Name = "b", Random = "c" };
+            ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();
+            counts.TryAdd($"Executed '{functionName}' (Succeeded", 1);
+            counts.TryAdd($"Value of key '{functionName}' is currently a type {value.GetType()}: '{JsonConvert.SerializeObject(value)}'", 1);
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+            {
+                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                await multiplexer.GetDatabase().StringSetAsync(functionName, JsonConvert.SerializeObject(value));
+                await multiplexer.GetSubscriber().PublishAsync(functionName, "start");
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                await multiplexer.CloseAsync();
+                functionsProcess.Kill();
+            };
+            var incorrect = counts.Where(pair => pair.Value != 0);
+            Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
     }
 }

--- a/test/dotnet/Integration/RedisInputBindingTests.cs
+++ b/test/dotnet/Integration/RedisInputBindingTests.cs
@@ -1,0 +1,74 @@
+﻿using StackExchange.Redis;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using Xunit;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
+{
+    [Collection("RedisTriggerTests")]
+    public class RedisInputBindingTests
+    {
+        [Fact]
+        public async void Get_SuccessfullyGets()
+        {
+            string functionName = nameof(RedisInputBindingTestFunctions.GetTester);
+            string value = "value";
+            ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();
+            counts.TryAdd($"Executed '{functionName}' (Succeeded", 1);
+            counts.TryAdd($"Value of key '{functionName}' is currently '{value}'", 1);
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            {
+                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+                await multiplexer.GetDatabase().StringSetAsync(functionName, value);
+
+                using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+                {
+                    functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                    await multiplexer.GetSubscriber().PublishAsync(functionName, "start");
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    await multiplexer.CloseAsync();
+                    functionsProcess.Kill();
+                };
+                var incorrect = counts.Where(pair => pair.Value != 0);
+                Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
+            }
+        }
+
+        [Fact]
+        public async void Hget_SuccessfullyGets()
+        {
+            string functionName = nameof(RedisInputBindingTestFunctions.HgetTester);
+            string value = "value";
+            ConcurrentDictionary<string, int> counts = new ConcurrentDictionary<string, int>();
+            counts.TryAdd($"Executed '{functionName}' (Succeeded", 1);
+            counts.TryAdd($"Value of field 'field' in hash '{functionName}' is currently '{value}'", 1);
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            {
+                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+                await multiplexer.GetDatabase().HashSetAsync(functionName, "field", value);
+
+                using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+                {
+                    functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                    await multiplexer.GetSubscriber().PublishAsync(functionName, "start");
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    await multiplexer.CloseAsync();
+                    functionsProcess.Kill();
+                };
+                var incorrect = counts.Where(pair => pair.Value != 0);
+                Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
+            }
+        }
+    }
+}

--- a/test/dotnet/Integration/RedisInputBindingTests.cs
+++ b/test/dotnet/Integration/RedisInputBindingTests.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
 using Xunit;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 {

--- a/test/dotnet/Integration/RedisPubSubTriggerTests.cs
+++ b/test/dotnet/Integration/RedisPubSubTriggerTests.cs
@@ -12,131 +12,131 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     [Collection("RedisTriggerTests")]
     public class RedisPubSubTriggerTests
     {
+        //[Theory]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "prefix" + RedisPubSubTriggerTestFunctions.pubsubChannel, "testPrefix")]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "separate", "testSeparate")]
+        //public async void PubSubTrigger_SuccessfullyTriggers(string functionName, string channel, string message)
+        //{
+        //    Dictionary<string, int> counts = new Dictionary<string, int>
+        //    {
+        //        { $"Executed '{functionName}' (Succeeded", 1},
+        //        { message, 1},
+        //    };
+
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+        //    {
+        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+        //        ISubscriber subscriber = multiplexer.GetSubscriber();
+
+        //        subscriber.Publish(channel, message);
+        //        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //        await multiplexer.CloseAsync();
+        //        functionsProcess.Kill();
+        //    };
+        //    var incorrect = counts.Where(pair => pair.Value != 0);
+        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        //}
+
+        //[Theory]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleKey), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
+        //public async void KeySpaceTrigger_SuccessfullyTriggers(string functionName, string channel)
+        //{
+        //    string keyspace = "__keyspace@0__:";
+        //    string key = channel.Substring(channel.IndexOf(keyspace) + keyspace.Length);
+        //    Dictionary<string, int> counts = new Dictionary<string, int>
+        //    {
+        //        { $"Executed '{functionName}' (Succeeded", 2},
+        //        { "set", 1},
+        //        { "del", 1},
+        //    };
+
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+        //    {
+        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+        //        IDatabase db = multiplexer.GetDatabase();
+
+        //        db.StringSet(key, "test");
+        //        db.KeyDelete(key);
+        //        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //        await multiplexer.CloseAsync();
+        //        functionsProcess.Kill();
+        //    };
+        //    var incorrect = counts.Where(pair => pair.Value != 0);
+        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        //}
+
+        //[Fact]
+        //public async void KeyEventTrigger_SingleEvent_SuccessfullyTriggers()
+        //{
+        //    string key = "keyTrigger";
+        //    string value = "value";
+        //    Dictionary<string, int> counts = new Dictionary<string, int>
+        //    {
+        //        { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.SingleEvent)}' (Succeeded", 1},
+        //        { key, 1},
+        //    };
+
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.SingleEvent), 7071))
+        //    {
+        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+        //        IDatabase db = multiplexer.GetDatabase();
+
+        //        db.StringSet(key, value);
+        //        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //        await multiplexer.CloseAsync();
+        //        functionsProcess.Kill();
+        //    };
+        //    var incorrect = counts.Where(pair => pair.Value != 0);
+        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        //}
+
+        //[Fact]
+        //public async void KeyEventTrigger_AllEvents_SuccessfullyTriggers()
+        //{
+        //    string key = "keyTrigger";
+        //    string value = "value";
+
+        //    Dictionary<string, int> counts = new Dictionary<string, int>
+        //    {
+        //        { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.AllEvents)}' (Succeeded", 2},
+        //        { key, 2},
+        //    };
+
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.AllEvents), 7071))
+        //    {
+        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+        //        IDatabase db = multiplexer.GetDatabase();
+
+        //        db.StringSet(key, value);
+        //        db.KeyDelete(key);
+        //        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        //        await multiplexer.CloseAsync();
+        //        functionsProcess.Kill();
+        //    };
+        //    var incorrect = counts.Where(pair => pair.Value != 0);
+        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        //}
+
         [Theory]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "prefix" + RedisPubSubTriggerTestFunctions.pubsubChannel, "testPrefix")]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "separate", "testSeparate")]
-        public async void PubSubTrigger_SuccessfullyTriggers(string functionName, string channel, string message)
-        {
-            Dictionary<string, int> counts = new Dictionary<string, int>
-            {
-                { $"Executed '{functionName}' (Succeeded", 1},
-                { message, 1},
-            };
-
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
-            {
-                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-                ISubscriber subscriber = multiplexer.GetSubscriber();
-
-                subscriber.Publish(channel, message);
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                await multiplexer.CloseAsync();
-                functionsProcess.Kill();
-            };
-            var incorrect = counts.Where(pair => pair.Value != 0);
-            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        }
-
-        [Theory]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleKey), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
-        public async void KeySpaceTrigger_SuccessfullyTriggers(string functionName, string channel)
-        {
-            string keyspace = "__keyspace@0__:";
-            string key = channel.Substring(channel.IndexOf(keyspace) + keyspace.Length);
-            Dictionary<string, int> counts = new Dictionary<string, int>
-            {
-                { $"Executed '{functionName}' (Succeeded", 2},
-                { "set", 1},
-                { "del", 1},
-            };
-
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
-            {
-                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-                IDatabase db = multiplexer.GetDatabase();
-
-                db.StringSet(key, "test");
-                db.KeyDelete(key);
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                await multiplexer.CloseAsync();
-                functionsProcess.Kill();
-            };
-            var incorrect = counts.Where(pair => pair.Value != 0);
-            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        }
-
-        [Fact]
-        public async void KeyEventTrigger_SingleEvent_SuccessfullyTriggers()
-        {
-            string key = "keyTrigger";
-            string value = "value";
-            Dictionary<string, int> counts = new Dictionary<string, int>
-            {
-                { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.SingleEvent)}' (Succeeded", 1},
-                { key, 1},
-            };
-
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.SingleEvent), 7071))
-            {
-                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-                IDatabase db = multiplexer.GetDatabase();
-
-                db.StringSet(key, value);
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                await multiplexer.CloseAsync();
-                functionsProcess.Kill();
-            };
-            var incorrect = counts.Where(pair => pair.Value != 0);
-            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        }
-
-        [Fact]
-        public async void KeyEventTrigger_AllEvents_SuccessfullyTriggers()
-        {
-            string key = "keyTrigger";
-            string value = "value";
-
-            Dictionary<string, int> counts = new Dictionary<string, int>
-            {
-                { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.AllEvents)}' (Succeeded", 2},
-                { key, 2},
-            };
-
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.AllEvents), 7071))
-            {
-                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-                IDatabase db = multiplexer.GetDatabase();
-
-                db.StringSet(key, value);
-                db.KeyDelete(key);
-                await Task.Delay(TimeSpan.FromSeconds(1));
-
-                await multiplexer.CloseAsync();
-                functionsProcess.Kill();
-            };
-            var incorrect = counts.Where(pair => pair.Value != 0);
-            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        }
-
-        [Theory]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_ChannelMessage), typeof(ChannelMessage))]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_RedisValue), typeof(RedisValue))]
-        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_String), typeof(string))]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_ChannelMessage), typeof(ChannelMessage))]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_RedisValue), typeof(RedisValue))]
+        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_String), typeof(string))]
         [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_CustomType), typeof(CustomType))]
         public async void PubSubTrigger_TypeConversions_WorkCorrectly(string functionName, Type destinationType)
         {

--- a/test/dotnet/Integration/RedisPubSubTriggerTests.cs
+++ b/test/dotnet/Integration/RedisPubSubTriggerTests.cs
@@ -12,131 +12,131 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     [Collection("RedisTriggerTests")]
     public class RedisPubSubTriggerTests
     {
-        //[Theory]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "prefix" + RedisPubSubTriggerTestFunctions.pubsubChannel, "testPrefix")]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "separate", "testSeparate")]
-        //public async void PubSubTrigger_SuccessfullyTriggers(string functionName, string channel, string message)
-        //{
-        //    Dictionary<string, int> counts = new Dictionary<string, int>
-        //    {
-        //        { $"Executed '{functionName}' (Succeeded", 1},
-        //        { message, 1},
-        //    };
+        [Theory]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel, "testValue")]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), RedisPubSubTriggerTestFunctions.pubsubChannel + "suffix", "testSuffix")]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "prefix" + RedisPubSubTriggerTestFunctions.pubsubChannel, "testPrefix")]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllChannels), "separate", "testSeparate")]
+        public async void PubSubTrigger_SuccessfullyTriggers(string functionName, string channel, string message)
+        {
+            Dictionary<string, int> counts = new Dictionary<string, int>
+            {
+                { $"Executed '{functionName}' (Succeeded", 1},
+                { message, 1},
+            };
 
-        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
-        //    {
-        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-        //        ISubscriber subscriber = multiplexer.GetSubscriber();
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+            {
+                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                ISubscriber subscriber = multiplexer.GetSubscriber();
 
-        //        subscriber.Publish(channel, message);
-        //        await Task.Delay(TimeSpan.FromSeconds(1));
+                subscriber.Publish(channel, message);
+                await Task.Delay(TimeSpan.FromSeconds(1));
 
-        //        await multiplexer.CloseAsync();
-        //        functionsProcess.Kill();
-        //    };
-        //    var incorrect = counts.Where(pair => pair.Value != 0);
-        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        //}
-
-        //[Theory]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleKey), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
-        //public async void KeySpaceTrigger_SuccessfullyTriggers(string functionName, string channel)
-        //{
-        //    string keyspace = "__keyspace@0__:";
-        //    string key = channel.Substring(channel.IndexOf(keyspace) + keyspace.Length);
-        //    Dictionary<string, int> counts = new Dictionary<string, int>
-        //    {
-        //        { $"Executed '{functionName}' (Succeeded", 2},
-        //        { "set", 1},
-        //        { "del", 1},
-        //    };
-
-        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
-        //    {
-        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-        //        IDatabase db = multiplexer.GetDatabase();
-
-        //        db.StringSet(key, "test");
-        //        db.KeyDelete(key);
-        //        await Task.Delay(TimeSpan.FromSeconds(1));
-
-        //        await multiplexer.CloseAsync();
-        //        functionsProcess.Kill();
-        //    };
-        //    var incorrect = counts.Where(pair => pair.Value != 0);
-        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        //}
-
-        //[Fact]
-        //public async void KeyEventTrigger_SingleEvent_SuccessfullyTriggers()
-        //{
-        //    string key = "keyTrigger";
-        //    string value = "value";
-        //    Dictionary<string, int> counts = new Dictionary<string, int>
-        //    {
-        //        { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.SingleEvent)}' (Succeeded", 1},
-        //        { key, 1},
-        //    };
-
-        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.SingleEvent), 7071))
-        //    {
-        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-        //        IDatabase db = multiplexer.GetDatabase();
-
-        //        db.StringSet(key, value);
-        //        await Task.Delay(TimeSpan.FromSeconds(1));
-
-        //        await multiplexer.CloseAsync();
-        //        functionsProcess.Kill();
-        //    };
-        //    var incorrect = counts.Where(pair => pair.Value != 0);
-        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        //}
-
-        //[Fact]
-        //public async void KeyEventTrigger_AllEvents_SuccessfullyTriggers()
-        //{
-        //    string key = "keyTrigger";
-        //    string value = "value";
-
-        //    Dictionary<string, int> counts = new Dictionary<string, int>
-        //    {
-        //        { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.AllEvents)}' (Succeeded", 2},
-        //        { key, 2},
-        //    };
-
-        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
-        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.AllEvents), 7071))
-        //    {
-        //        functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
-        //        IDatabase db = multiplexer.GetDatabase();
-
-        //        db.StringSet(key, value);
-        //        db.KeyDelete(key);
-        //        await Task.Delay(TimeSpan.FromSeconds(1));
-
-        //        await multiplexer.CloseAsync();
-        //        functionsProcess.Kill();
-        //    };
-        //    var incorrect = counts.Where(pair => pair.Value != 0);
-        //    Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
-        //}
+                await multiplexer.CloseAsync();
+                functionsProcess.Kill();
+            };
+            var incorrect = counts.Where(pair => pair.Value != 0);
+            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        }
 
         [Theory]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_ChannelMessage), typeof(ChannelMessage))]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_RedisValue), typeof(RedisValue))]
-        //[InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_String), typeof(string))]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleKey), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.MultipleKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel)]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.AllKeys), RedisPubSubTriggerTestFunctions.keyspaceChannel + "suffix")]
+        public async void KeySpaceTrigger_SuccessfullyTriggers(string functionName, string channel)
+        {
+            string keyspace = "__keyspace@0__:";
+            string key = channel.Substring(channel.IndexOf(keyspace) + keyspace.Length);
+            Dictionary<string, int> counts = new Dictionary<string, int>
+            {
+                { $"Executed '{functionName}' (Succeeded", 2},
+                { "set", 1},
+                { "del", 1},
+            };
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, 7071))
+            {
+                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                IDatabase db = multiplexer.GetDatabase();
+
+                db.StringSet(key, "test");
+                db.KeyDelete(key);
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                await multiplexer.CloseAsync();
+                functionsProcess.Kill();
+            };
+            var incorrect = counts.Where(pair => pair.Value != 0);
+            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        }
+
+        [Fact]
+        public async void KeyEventTrigger_SingleEvent_SuccessfullyTriggers()
+        {
+            string key = "keyTrigger";
+            string value = "value";
+            Dictionary<string, int> counts = new Dictionary<string, int>
+            {
+                { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.SingleEvent)}' (Succeeded", 1},
+                { key, 1},
+            };
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.SingleEvent), 7071))
+            {
+                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                IDatabase db = multiplexer.GetDatabase();
+
+                db.StringSet(key, value);
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                await multiplexer.CloseAsync();
+                functionsProcess.Kill();
+            };
+            var incorrect = counts.Where(pair => pair.Value != 0);
+            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        }
+
+        [Fact]
+        public async void KeyEventTrigger_AllEvents_SuccessfullyTriggers()
+        {
+            string key = "keyTrigger";
+            string value = "value";
+
+            Dictionary<string, int> counts = new Dictionary<string, int>
+            {
+                { $"Executed '{nameof(RedisPubSubTriggerTestFunctions.AllEvents)}' (Succeeded", 2},
+                { key, 2},
+            };
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisPubSubTriggerTestFunctions.localhostSetting)))
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(nameof(RedisPubSubTriggerTestFunctions.AllEvents), 7071))
+            {
+                functionsProcess.OutputDataReceived += IntegrationTestHelpers.CounterHandlerCreator(counts);
+                IDatabase db = multiplexer.GetDatabase();
+
+                db.StringSet(key, value);
+                db.KeyDelete(key);
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                await multiplexer.CloseAsync();
+                functionsProcess.Kill();
+            };
+            var incorrect = counts.Where(pair => pair.Value != 0);
+            Assert.False(incorrect.Any(), JsonSerializer.Serialize(incorrect));
+        }
+
+        [Theory]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_ChannelMessage), typeof(ChannelMessage))]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_RedisValue), typeof(RedisValue))]
+        [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_String), typeof(string))]
         [InlineData(nameof(RedisPubSubTriggerTestFunctions.SingleChannel_CustomType), typeof(CustomType))]
         public async void PubSubTrigger_TypeConversions_WorkCorrectly(string functionName, Type destinationType)
         {


### PR DESCRIPTION
This PR adds Input Bindings that allow redis commands to be run against a Redis server.
The command field takes the entire command as a single string (similar to how redis-cli would), executes it, and then returns the result to the caller.

Currently the only commands allowed are readonly commands that return a single value back to the caller. readonly is to ensure that the input binding functions don't modify the keyspace, and returning a single value is currently for simplicity of the binding logic. More commands with more sophisticated output types will be added in the future. 