### PR TITLE
remove messagesPerWorker argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ The `RedisListTrigger` pops entries from a list and surfaces those entries to th
   - This field can be resolved using `INameResolver`.
 - `PollingIntervalInMs`: How often to poll Redis in milliseconds.
   - Default: `1000`
-- `MessagesPerWorker`: How many messages each functions instance "should" process. Used to determine how many instances the function should scale to.
-  - Default: `100`
 - `Count`: Number of entries to pop from Redis at one time. These are processed in parallel.
   - Default: `10`
   - Only supported on Redis 6.2+ using the `COUNT` argument in [`LPOP`](https://redis.io/commands/lpop/)/[`RPOP`](https://redis.io/commands/rpop/).
@@ -100,8 +98,6 @@ Each functions instance creates a new random GUID to use as its consumer name wi
   - This field can be resolved using `INameResolver`.
 - `PollingIntervalInMs`: How often to poll Redis in milliseconds.
   - Default: `1000`
-- `MessagesPerWorker`: How many messages each functions instance "should" process. Used to determine how many instances the function should scale to.
-  - Default: `100`
 - `Count`: Number of entries to read from Redis at one time. These are processed in parallel.
   - Default: `10`
 - `DeleteAfterProcess`: Whether to delete the stream entries after the function has run.

--- a/samples/java/src/main/java/com/function/RedisSamples.java
+++ b/samples/java/src/main/java/com/function/RedisSamples.java
@@ -56,7 +56,6 @@ public class RedisSamples {
                 connectionStringSetting = "redisLocalhost",
                 key = "listTest",
                 pollingIntervalInMs = 100,
-                messagesPerWorker = 10,
                 count = 1,
                 listPopFromBeginning = false)
                 String entry,
@@ -71,7 +70,6 @@ public class RedisSamples {
                 connectionStringSetting = "redisLocalhost",
                 key = "streamTest",
                 pollingIntervalInMs = 100,
-                messagesPerWorker = 10,
                 count = 1,
                 deleteAfterProcess = true)
                 String entry,

--- a/samples/node/ListTrigger/function.json
+++ b/samples/node/ListTrigger/function.json
@@ -6,7 +6,6 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "listTest",
       "pollingIntervalInMs": 1000,
-      "messagesPerWorker": 100,
       "count": 10,
       "name": "entry",
       "direction": "in"

--- a/samples/node/StreamTrigger/function.json
+++ b/samples/node/StreamTrigger/function.json
@@ -6,7 +6,6 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,
-      "messagesPerWorker": 100,
       "count": 10,
       "name": "entry",
       "direction": "in"

--- a/samples/powershell/ListTrigger/function.json
+++ b/samples/powershell/ListTrigger/function.json
@@ -6,7 +6,6 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "listTest",
       "pollingIntervalInMs": 1000,
-      "messagesPerWorker": 100,
       "count": 10,
       "name": "entry",
       "direction": "in"

--- a/samples/powershell/StreamTrigger/function.json
+++ b/samples/powershell/StreamTrigger/function.json
@@ -6,7 +6,6 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,
-      "messagesPerWorker": 100,
       "count": 10,
       "name": "entry",
       "direction": "in"

--- a/samples/python/ListTrigger/function.json
+++ b/samples/python/ListTrigger/function.json
@@ -6,7 +6,6 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "listTest",
       "pollingIntervalInMs": 1000,
-      "messagesPerWorker": 100,
       "count": 10,
       "name": "entry",
       "direction": "in"

--- a/samples/python/StreamTrigger/function.json
+++ b/samples/python/StreamTrigger/function.json
@@ -6,7 +6,6 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,
-      "messagesPerWorker": 100,
       "count": 10,
       "name": "entry",
       "direction": "in"

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisListTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisListTriggerAttribute.cs
@@ -13,15 +13,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
-        /// <param name="messagesPerWorker">The number of messages each functions instance is expected to handle.</param>
         /// <param name="count">Number of entries to pull from Redis at one time.</param>
         /// <param name="listPopFromBeginning">Decides if the function will pop entries from the front or end of the list. Default: true</param>
-        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int messagesPerWorker = 100, int count = 10, bool listPopFromBeginning = true)
+        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool listPopFromBeginning = true)
         {
             ConnectionStringSetting = connectionStringSetting;
             Key = key;
             PollingIntervalInMs = pollingIntervalInMs;
-            MessagesPerWorker = messagesPerWorker;
             Count = count;
             ListPopFromBeginning = listPopFromBeginning;
         }
@@ -41,15 +39,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// How often to poll Redis in milliseconds.
         /// </summary>
         public int PollingIntervalInMs { get; }
-
-        /// <summary>
-        /// The number of messages each functions instance is expected to handle.
-        /// Used to determine how many workers the function should scale to.
-        /// For example, if the number of <see cref="MessagesPerWorker">MessagesPerWorker</see> is 10,
-        /// and there are 1500 entries remaining in the list,
-        /// the functions host will attempt to scale up to 150 instances.
-        /// </summary>
-        public int MessagesPerWorker { get; }
 
         /// <summary>
         /// Number of entries to pull from Redis at one time.

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
@@ -13,15 +13,13 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
-        /// <param name="messagesPerWorker">The number of messages each functions instance is expected to handle.</param>
         /// <param name="count">Number of entries to pull from Redis at one time.</param>
         /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int messagesPerWorker = 100, int count = 10, bool deleteAfterProcess = false)
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool deleteAfterProcess = false)
         {
             ConnectionStringSetting = connectionStringSetting;
             Key = key;
             PollingIntervalInMs = pollingIntervalInMs;
-            MessagesPerWorker = messagesPerWorker;
             Count = count;
             DeleteAfterProcess = deleteAfterProcess;
         }
@@ -41,15 +39,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// How often to poll Redis in milliseconds.
         /// </summary>
         public int PollingIntervalInMs { get; }
-
-        /// <summary>
-        /// The number of messages each functions instance is expected to handle.
-        /// Used to determine how many workers the function should scale to.
-        /// For example, if the number of <see cref="MessagesPerWorker">MessagesPerWorker</see> is 10,
-        /// and there are 1500 entries remaining in the list,
-        /// the functions host will attempt to scale up to 150 instances.
-        /// </summary>
-        public int MessagesPerWorker { get; }
 
         /// <summary>
         /// Number of entries to pull from Redis at one time.

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListListener.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     {
         internal bool listPopFromBeginning;
 
-        public RedisListListener(string name, string connectionString, string key, TimeSpan pollingInterval, int messagesPerWorker, int count, bool listPopFromBeginning, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, connectionString, key, pollingInterval, messagesPerWorker, count, executor, logger)
+        public RedisListListener(string name, string connectionString, string key, TimeSpan pollingInterval, int count, bool listPopFromBeginning, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, connectionString, key, pollingInterval, count, executor, logger)
         {
             this.listPopFromBeginning = listPopFromBeginning;
             this.logPrefix = $"[Name:{name}][Trigger:RedisListTrigger][Key:{key}]";

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerAttribute.cs
@@ -16,11 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="messagesPerWorker">The number of messages each functions instance is expected to handle. Default: 100</param>
         /// <param name="count">Number of entries to pull from a Redis list at one time. Default: 10</param>
         /// <param name="listPopFromBeginning">Decides if the function will pop entries from the front or end of the list. Default: true</param>
-        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int messagesPerWorker = 100, int count = 10, bool listPopFromBeginning = true)
-            : base(connectionStringSetting, key, pollingIntervalInMs, messagesPerWorker, count)
+        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool listPopFromBeginning = true)
+            : base(connectionStringSetting, key, pollingIntervalInMs, count)
         {
             ListPopFromBeginning = listPopFromBeginning;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
@@ -17,19 +17,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     {
         private readonly string connectionString;
         private readonly TimeSpan pollingInterval;
-        private readonly int messagesPerWorker;
         private readonly string key;
         private readonly int count;
         private readonly bool listPopFromBeginning;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisListTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int messagesPerWorker, int count, bool listPopFromBeginning, Type parameterType, ILogger logger)
+        public RedisListTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int count, bool listPopFromBeginning, Type parameterType, ILogger logger)
         {
             this.connectionString = connectionString;
             this.key = key;
             this.pollingInterval = pollingInterval;
-            this.messagesPerWorker = messagesPerWorker;
             this.count = count;
             this.listPopFromBeginning = listPopFromBeginning;
             this.parameterType = parameterType;
@@ -55,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisListListener(context.Descriptor.LogName, connectionString, key, pollingInterval, messagesPerWorker, count, listPopFromBeginning, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisListListener(context.Descriptor.LogName, connectionString, key, pollingInterval, count, listPopFromBeginning, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBindingProvider.cs
@@ -42,12 +42,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
             string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
-            int messagesPerWorker = attribute.MessagesPerWorker;
             int count = attribute.Count;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
             bool listPopFromBeginning = attribute.ListPopFromBeginning;
 
-            return Task.FromResult<ITriggerBinding>(new RedisListTriggerBinding(connectionString, key, pollingInterval, messagesPerWorker, count, listPopFromBeginning, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisListTriggerBinding(connectionString, key, pollingInterval, count, listPopFromBeginning, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseAttribute.cs
@@ -14,14 +14,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
-        /// <param name="messagesPerWorker">The number of messages each functions instance is expected to handle.</param>
-        /// <param name="count">Number of entries to pull from Redis at one time.</param>
-        public RedisPollingTriggerBaseAttribute(string connectionStringSetting, string key, int pollingIntervalInMs, int messagesPerWorker, int count)
+        /// <param name="count">Number of entries to pull from Redis at one time. Used to determine scaling.</param>
+        public RedisPollingTriggerBaseAttribute(string connectionStringSetting, string key, int pollingIntervalInMs, int count)
         {
             this.ConnectionStringSetting = connectionStringSetting;
             this.Key = key;
             this.PollingIntervalInMs = pollingIntervalInMs;
-            this.MessagesPerWorker = messagesPerWorker;
             this.Count = count;
         }
 
@@ -42,15 +40,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// How often to poll Redis in milliseconds.
         /// </summary>
         public int PollingIntervalInMs { get; }
-
-        /// <summary>
-        /// The number of messages each functions instance is expected to handle.
-        /// Used to determine how many workers the function should scale to.
-        /// For example, if the number of <see cref="MessagesPerWorker">MessagesPerWorker</see> is 10,
-        /// and there are 1500 entries remaining in the list,
-        /// the functions host will attempt to scale up to 150 instances.
-        /// </summary>
-        public int MessagesPerWorker { get; }
 
         /// <summary>
         /// Number of entries to pull from Redis at one time.

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal string consumerGroup;
         internal string consumerName;
 
-        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int messagesPerWorker, int count, string consumerGroup, bool deleteAfterProcess, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, connectionString, key, pollingInterval, messagesPerWorker, count, executor, logger)
+        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int count, string consumerGroup, bool deleteAfterProcess, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, connectionString, key, pollingInterval, count, executor, logger)
         {
             this.consumerGroup = consumerGroup;
             this.deleteAfterProcess = deleteAfterProcess;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
@@ -16,11 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="messagesPerWorker">The number of messages each functions instance is expected to handle. Default: 100</param>
         /// <param name="count">Number of entries to pull from a Redis stream at one time. Default: 10</param>
         /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int messagesPerWorker = 100, int count = 10, bool deleteAfterProcess = false)
-            : base(connectionStringSetting, key, pollingIntervalInMs, messagesPerWorker, count)
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool deleteAfterProcess = false)
+            : base(connectionStringSetting, key, pollingIntervalInMs, count)
         {
             DeleteAfterProcess = deleteAfterProcess;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
@@ -17,19 +17,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     {
         private readonly string connectionString;
         private readonly TimeSpan pollingInterval;
-        private readonly int messagesPerWorker;
         private readonly string key;
         private readonly int count;
         private readonly bool deleteAfterProcess;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int messagesPerWorker, int count, bool deleteAfterProcess, Type parameterType, ILogger logger)
+        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int count, bool deleteAfterProcess, Type parameterType, ILogger logger)
         {
             this.connectionString = connectionString;
             this.key = key;
             this.pollingInterval = pollingInterval;
-            this.messagesPerWorker = messagesPerWorker;
             this.count = count;
             this.deleteAfterProcess = deleteAfterProcess;
             this.parameterType = parameterType;
@@ -54,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, messagesPerWorker, count, context.Descriptor.Id, deleteAfterProcess, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, count, context.Descriptor.Id, deleteAfterProcess, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
@@ -42,12 +42,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
             string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
-            int messagesPerWorker = attribute.MessagesPerWorker;
             int count = attribute.Count;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
             bool deleteAfterProcess = attribute.DeleteAfterProcess;
 
-            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, messagesPerWorker, count, deleteAfterProcess, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, count, deleteAfterProcess, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
@@ -70,16 +70,6 @@ public @interface RedisListTrigger {
     int pollingIntervalInMs() default 1000;
 
     /**
-     * How many messages each functions worker should process.
-     * Used to determine how many workers the function should scale to.
-     * For example, if the messagesPerWorker is 10,
-     * and there are 1500 entries remaining in the list,
-     * the functions host will attempt to scale up to 150 instances.
-     * @return How many messages each functions worker should process.
-     */
-    int messagesPerWorker() default 100;
-
-    /**
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
@@ -70,16 +70,6 @@ public @interface RedisStreamTrigger {
     int pollingIntervalInMs() default 1000;
 
     /**
-     * How many messages each functions worker should process.
-     * Used to determine how many workers the function should scale to.
-     * For example, if the messagesPerWorker is 10,
-     * and there are 1500 entries remaining in the list,
-     * the functions host will attempt to scale up to 150 instances.
-     * @return How many messages each functions worker should process.
-     */
-    int messagesPerWorker() default 100;
-
-    /**
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */

--- a/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(ListTrigger_RedisValue_LongPollingInterval))]
         public static void ListTrigger_RedisValue_LongPollingInterval(
-            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue_LongPollingInterval), pollingIntervalInMs: pollingIntervalLong, messagesPerWorker: 1, count: 1)] RedisValue entry,
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue_LongPollingInterval), pollingIntervalInMs: pollingIntervalLong, count: 1)] RedisValue entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));

--- a/test/dotnet/Unit/RedisPollingListenerBaseTests.cs
+++ b/test/dotnet/Unit/RedisPollingListenerBaseTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
     {
         private const string name = nameof(RedisPollingListenerBaseTests);
         private const string connectionString = "127.0.0.1:6379";
-        private const int defaultMessagesPerWorker = 10;
         private const int defaultCount = 10;
         private const string key = "a";
         private TimeSpan defaultPollingInterval = TimeSpan.FromMilliseconds(100);
@@ -66,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [Fact]
         public async void StartAsync_CreatesConnectionMultiplexerAsync()
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, defaultMessagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             await listener.StartAsync(new CancellationToken());
             Assert.NotNull(listener.multiplexer);
             Assert.Equal(connectionString, listener.multiplexer.Configuration, ignoreCase: true);
@@ -75,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [Fact]
         public async void StopAsync_ClosesAndDisposesConnectionMultiplexerAsync()
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, defaultMessagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             listener.multiplexer = A.Fake<IConnectionMultiplexer>();
             await listener.StopAsync(new CancellationToken());
             A.CallTo(() => listener.multiplexer.CloseAsync(A<bool>._)).MustHaveHappened();
@@ -89,9 +88,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(5, 10, ScaleVote.None)]
         [InlineData(3, 30, ScaleVote.ScaleIn)]
         [InlineData(5, 20, ScaleVote.ScaleIn)]
-        public void ScalingLogic_ConstantMetrics(int workerCount, int messagesPerWorker, ScaleVote expected)
+        public void ScalingLogic_ConstantMetrics(int workerCount, int count, ScaleVote expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, messagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, count, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = constantMetrics };
             Assert.Equal(expected, listener.GetScaleStatus(context).Vote);
         }
@@ -103,9 +102,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(5, 10)]
         [InlineData(3, 30)]
         [InlineData(5, 20)]
-        public void ScalingLogic_FewMetrics(int workerCount, int messagesPerWorker)
+        public void ScalingLogic_FewMetrics(int workerCount, int count)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, messagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, count, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = fewMetrics };
             Assert.Equal(ScaleVote.None, listener.GetScaleStatus(context).Vote);
         }
@@ -115,9 +114,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(3, 10, ScaleVote.None)]
         [InlineData(1, 100, ScaleVote.None)]
         [InlineData(10, 10, ScaleVote.ScaleIn)]
-        public void ScalingLogic_DecreasingMetrics(int workerCount, int messagesPerWorker, ScaleVote expected)
+        public void ScalingLogic_DecreasingMetrics(int workerCount, int count, ScaleVote expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, messagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, count, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = decreasingMetrics };
             Assert.Equal(expected, listener.GetScaleStatus(context).Vote);
         }
@@ -127,9 +126,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(7, 10, ScaleVote.None)]
         [InlineData(1, 100, ScaleVote.None)]
         [InlineData(10, 10, ScaleVote.ScaleIn)]
-        public void ScalingLogic_IncreasingMetrics(int workerCount, int messagesPerWorker, ScaleVote expected)
+        public void ScalingLogic_IncreasingMetrics(int workerCount, int count, ScaleVote expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, messagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, count, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = increasingMetrics };
             Assert.Equal(expected, listener.GetScaleStatus(context).Vote);
         }
@@ -142,9 +141,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(1000, 50, 20)]
         [InlineData(5000, 100, 50)]
         [InlineData(10000, 10, 1000)]
-        public async Task TargetScaler_IncreasingMetricsAsync(long remaining, int messagesPerWorker, int expected)
+        public async Task TargetScaler_IncreasingMetricsAsync(long remaining, int count, int expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, messagesPerWorker, defaultCount, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, count, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             IDatabase fakeDatabase = A.Fake<IDatabase>();
             A.CallTo(() => fakeDatabase.ListLength(A<RedisKey>._, A<CommandFlags>._)).Returns(remaining);
             IConnectionMultiplexer fakeMultiplexer = A.Fake<IConnectionMultiplexer>();


### PR DESCRIPTION
Removing the `messagesPerWorker` argument as it introduces more complexity into the scaling logic. Scaling should be driven by the `count` argument instead.