### PR TITLE
Rename Count to MaxBatchSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ The `RedisListTrigger` pops entries from a list and surfaces those entries to th
   - This field can be resolved using `INameResolver`.
 - `PollingIntervalInMs`: How often to poll Redis in milliseconds.
   - Default: `1000`
-- `Count`: Number of entries to pop from Redis at one time. These are processed in parallel.
-  - Default: `10`
+- `MaxBatchSize`: Number of entries to pop from Redis at one time. These are processed in parallel.
+  - Default: `16`
   - Only supported on Redis 6.2+ using the `COUNT` argument in [`LPOP`](https://redis.io/commands/lpop/)/[`RPOP`](https://redis.io/commands/rpop/).
 - `ListPopFromBeginning`: determines whether to pop entries from the beginning using [`LPOP`](https://redis.io/commands/lpop/) or to pop entries from the end using [`RPOP`](https://redis.io/commands/rpop/).
   - Default: `true`
@@ -98,8 +98,8 @@ Each functions instance creates a new random GUID to use as its consumer name wi
   - This field can be resolved using `INameResolver`.
 - `PollingIntervalInMs`: How often to poll Redis in milliseconds.
   - Default: `1000`
-- `Count`: Number of entries to read from Redis at one time. These are processed in parallel.
-  - Default: `10`
+- `MaxBatchSize`: Number of entries to read from Redis at one time. These are processed in parallel.
+  - Default: `16`
 - `DeleteAfterProcess`: Whether to delete the stream entries after the function has run.
   - Default: `false`
 

--- a/samples/java/src/main/java/com/function/RedisSamples.java
+++ b/samples/java/src/main/java/com/function/RedisSamples.java
@@ -56,7 +56,7 @@ public class RedisSamples {
                 connectionStringSetting = "redisLocalhost",
                 key = "listTest",
                 pollingIntervalInMs = 100,
-                count = 1,
+                maxBatchSize = 1,
                 listPopFromBeginning = false)
                 String entry,
             final ExecutionContext context) {
@@ -70,7 +70,7 @@ public class RedisSamples {
                 connectionStringSetting = "redisLocalhost",
                 key = "streamTest",
                 pollingIntervalInMs = 100,
-                count = 1,
+                maxBatchSize = 1,
                 deleteAfterProcess = true)
                 String entry,
             final ExecutionContext context) {

--- a/samples/node/ListTrigger/function.json
+++ b/samples/node/ListTrigger/function.json
@@ -6,7 +6,7 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "listTest",
       "pollingIntervalInMs": 1000,
-      "count": 10,
+      "maxBatchSize": 10,
       "name": "entry",
       "direction": "in"
     }

--- a/samples/node/StreamTrigger/function.json
+++ b/samples/node/StreamTrigger/function.json
@@ -6,7 +6,7 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,
-      "count": 10,
+      "maxBatchSize": 10,
       "name": "entry",
       "direction": "in"
     }

--- a/samples/powershell/ListTrigger/function.json
+++ b/samples/powershell/ListTrigger/function.json
@@ -6,7 +6,7 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "listTest",
       "pollingIntervalInMs": 1000,
-      "count": 10,
+      "maxBatchSize": 10,
       "name": "entry",
       "direction": "in"
     }

--- a/samples/powershell/StreamTrigger/function.json
+++ b/samples/powershell/StreamTrigger/function.json
@@ -6,7 +6,7 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,
-      "count": 10,
+      "maxBatchSize": 10,
       "name": "entry",
       "direction": "in"
     }

--- a/samples/python/ListTrigger/function.json
+++ b/samples/python/ListTrigger/function.json
@@ -6,7 +6,7 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "listTest",
       "pollingIntervalInMs": 1000,
-      "count": 10,
+      "maxBatchSize": 10,
       "name": "entry",
       "direction": "in"
     }

--- a/samples/python/StreamTrigger/function.json
+++ b/samples/python/StreamTrigger/function.json
@@ -6,7 +6,7 @@
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,
-      "count": 10,
+      "maxBatchSize": 10,
       "name": "entry",
       "direction": "in"
     }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisListTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisListTriggerAttribute.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
-        /// <param name="count">Number of entries to pull from Redis at one time.</param>
+        /// <param name="maxBatchSize">Number of entries to pull from Redis at one time.</param>
         /// <param name="listPopFromBeginning">Decides if the function will pop entries from the front or end of the list. Default: true</param>
-        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool listPopFromBeginning = true)
+        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool listPopFromBeginning = true)
         {
             ConnectionStringSetting = connectionStringSetting;
             Key = key;
             PollingIntervalInMs = pollingIntervalInMs;
-            Count = count;
+            MaxBatchSize = maxBatchSize;
             ListPopFromBeginning = listPopFromBeginning;
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <summary>
         /// Number of entries to pull from Redis at one time.
         /// </summary>
-        public int Count { get; }
+        public int MaxBatchSize { get; }
 
         /// <summary>
         /// Decides if the function will pop entries from the front or end of the list.

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
@@ -13,14 +13,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
-        /// <param name="count">Number of entries to pull from Redis at one time.</param>
+        /// <param name="maxBatchSize">Number of entries to pull from Redis at one time.</param>
         /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool deleteAfterProcess = false)
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 10, bool deleteAfterProcess = false)
         {
             ConnectionStringSetting = connectionStringSetting;
             Key = key;
             PollingIntervalInMs = pollingIntervalInMs;
-            Count = count;
+            MaxBatchSize = maxBatchSize;
             DeleteAfterProcess = deleteAfterProcess;
         }
 
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <summary>
         /// Number of entries to pull from Redis at one time.
         /// </summary>
-        public int Count { get; }
+        public int MaxBatchSize { get; }
 
         /// <summary>
         /// Decides if the function will delete the stream entries after processing.

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
         /// <param name="maxBatchSize">Number of entries to pull from Redis at one time.</param>
         /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 10, bool deleteAfterProcess = false)
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool deleteAfterProcess = false)
         {
             ConnectionStringSetting = connectionStringSetting;
             Key = key;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="maxBatchSize">Number of entries to pull from a Redis list at one time. Default: 10</param>
+        /// <param name="maxBatchSize">Number of entries to pull from a Redis list at one time. Default: 16</param>
         /// <param name="listPopFromBeginning">Decides if the function will pop entries from the front or end of the list. Default: true</param>
         public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool listPopFromBeginning = true)
             : base(connectionStringSetting, key, pollingIntervalInMs, maxBatchSize)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerAttribute.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="count">Number of entries to pull from a Redis list at one time. Default: 10</param>
+        /// <param name="maxBatchSize">Number of entries to pull from a Redis list at one time. Default: 10</param>
         /// <param name="listPopFromBeginning">Decides if the function will pop entries from the front or end of the list. Default: true</param>
-        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool listPopFromBeginning = true)
-            : base(connectionStringSetting, key, pollingIntervalInMs, count)
+        public RedisListTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool listPopFromBeginning = true)
+            : base(connectionStringSetting, key, pollingIntervalInMs, maxBatchSize)
         {
             ListPopFromBeginning = listPopFromBeginning;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
@@ -18,17 +18,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         private readonly string connectionString;
         private readonly TimeSpan pollingInterval;
         private readonly string key;
-        private readonly int count;
+        private readonly int maxBatchSize;
         private readonly bool listPopFromBeginning;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisListTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int count, bool listPopFromBeginning, Type parameterType, ILogger logger)
+        public RedisListTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, Type parameterType, ILogger logger)
         {
             this.connectionString = connectionString;
             this.key = key;
             this.pollingInterval = pollingInterval;
-            this.count = count;
+            this.maxBatchSize = maxBatchSize;
             this.listPopFromBeginning = listPopFromBeginning;
             this.parameterType = parameterType;
             this.logger = logger;
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisListListener(context.Descriptor.LogName, connectionString, key, pollingInterval, count, listPopFromBeginning, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisListListener(context.Descriptor.LogName, connectionString, key, pollingInterval, maxBatchSize, listPopFromBeginning, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBindingProvider.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
             string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
-            int count = attribute.Count;
+            int maxBatchSize = attribute.MaxBatchSize;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
             bool listPopFromBeginning = attribute.ListPopFromBeginning;
 
-            return Task.FromResult<ITriggerBinding>(new RedisListTriggerBinding(connectionString, key, pollingInterval, count, listPopFromBeginning, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisListTriggerBinding(connectionString, key, pollingInterval, maxBatchSize, listPopFromBeginning, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseAttribute.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
-        /// <param name="count">Number of entries to pull from Redis at one time. Used to determine scaling.</param>
-        public RedisPollingTriggerBaseAttribute(string connectionStringSetting, string key, int pollingIntervalInMs, int count)
+        /// <param name="maxBatchSize">Number of entries to pull from Redis at one time. Used to determine scaling.</param>
+        public RedisPollingTriggerBaseAttribute(string connectionStringSetting, string key, int pollingIntervalInMs, int maxBatchSize)
         {
             this.ConnectionStringSetting = connectionStringSetting;
             this.Key = key;
             this.PollingIntervalInMs = pollingIntervalInMs;
-            this.Count = count;
+            this.MaxBatchSize = maxBatchSize;
         }
 
         /// <summary>
@@ -44,6 +44,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <summary>
         /// Number of entries to pull from Redis at one time.
         /// </summary>
-        public int Count { get; }
+        public int MaxBatchSize { get; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal string consumerGroup;
         internal string consumerName;
 
-        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int count, string consumerGroup, bool deleteAfterProcess, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, connectionString, key, pollingInterval, count, executor, logger)
+        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, string consumerGroup, bool deleteAfterProcess, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, connectionString, key, pollingInterval, maxBatchSize, executor, logger)
         {
             this.consumerGroup = consumerGroup;
             this.deleteAfterProcess = deleteAfterProcess;
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         public override async Task PollAsync(CancellationToken cancellationToken)
         {
             IDatabase db = multiplexer.GetDatabase();
-            StreamEntry[] entries = await db.StreamReadGroupAsync(key, consumerGroup, consumerName, count: count);
+            StreamEntry[] entries = await db.StreamReadGroupAsync(key, consumerGroup, consumerName, count: maxBatchSize);
             logger?.LogDebug($"{logPrefix} Received {entries.Length} entries from the stream at key '{key}'.");
             await Task.WhenAll(entries.Select(entry => ExecuteAsync(entry, cancellationToken)));
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 10</param>
+        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 16</param>
         /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
         public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool deleteAfterProcess = false)
             : base(connectionStringSetting, key, pollingIntervalInMs, maxBatchSize)

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="count">Number of entries to pull from a Redis stream at one time. Default: 10</param>
+        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 10</param>
         /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int count = 10, bool deleteAfterProcess = false)
-            : base(connectionStringSetting, key, pollingIntervalInMs, count)
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool deleteAfterProcess = false)
+            : base(connectionStringSetting, key, pollingIntervalInMs, maxBatchSize)
         {
             DeleteAfterProcess = deleteAfterProcess;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
@@ -18,17 +18,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         private readonly string connectionString;
         private readonly TimeSpan pollingInterval;
         private readonly string key;
-        private readonly int count;
+        private readonly int maxBatchSize;
         private readonly bool deleteAfterProcess;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int count, bool deleteAfterProcess, Type parameterType, ILogger logger)
+        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, bool deleteAfterProcess, Type parameterType, ILogger logger)
         {
             this.connectionString = connectionString;
             this.key = key;
             this.pollingInterval = pollingInterval;
-            this.count = count;
+            this.maxBatchSize = maxBatchSize;
             this.deleteAfterProcess = deleteAfterProcess;
             this.parameterType = parameterType;
             this.logger = logger;
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, count, context.Descriptor.Id, deleteAfterProcess, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, maxBatchSize, context.Descriptor.Id, deleteAfterProcess, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
             string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
-            int count = attribute.Count;
+            int maxBatchSize = attribute.MaxBatchSize;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
             bool deleteAfterProcess = attribute.DeleteAfterProcess;
 
-            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, count, deleteAfterProcess, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, maxBatchSize, deleteAfterProcess, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
@@ -73,7 +73,7 @@ public @interface RedisListTrigger {
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */
-    int count() default 10;
+    int maxBatchSize() default 10;
 
     /**
      * Determines whether to pop entries from the beginning using LPOP or to pop entries from the end using RPOP.

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
@@ -73,7 +73,7 @@ public @interface RedisStreamTrigger {
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */
-    int count() default 10;
+    int maxBatchSize() default 10;
 
     /**
      * Whether the listener will delete the stream entries after the function runs.

--- a/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(ListTrigger_RedisValue_LongPollingInterval))]
         public static void ListTrigger_RedisValue_LongPollingInterval(
-            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue_LongPollingInterval), pollingIntervalInMs: pollingIntervalLong, count: 1)] RedisValue entry,
+            [RedisListTrigger(localhostSetting, nameof(ListTrigger_RedisValue_LongPollingInterval), pollingIntervalInMs: pollingIntervalLong, maxBatchSize: 1)] RedisValue entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));

--- a/test/dotnet/Integration/RedisStreamTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisStreamTriggerTestFunctions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     {
         public const string localhostSetting = "redisLocalhost";
         public const int pollingInterval = 100;
-        public const int count = 100;
+        public const int batchSize = 100;
 
         [FunctionName(nameof(StreamTrigger_StreamEntry))]
         public static void StreamTrigger_StreamEntry(


### PR DESCRIPTION
This brings us in line with the rest of the extensions in calling the batches as MaxBatchSize and setting the default value to 16.