### PR TITLE
Remove deleteAfterProcess parameter from RedisStreamTrigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ Each functions instance creates a new random GUID to use as its consumer name wi
   - Default: `1000`
 - `MaxBatchSize`: Number of entries to read from Redis at one time. These are processed in parallel.
   - Default: `16`
-- `DeleteAfterProcess`: Whether to delete the stream entries after the function has run.
-  - Default: `false`
 
 #### Avaiable Output Types
 - [`StackExchange.Redis.StreamEntry`](https://github.com/StackExchange/StackExchange.Redis/blob/main/src/StackExchange.Redis/APITypes/StreamEntry.cs): The value returned by `StackExchange.Redis`.

--- a/samples/java/src/main/java/com/function/RedisSamples.java
+++ b/samples/java/src/main/java/com/function/RedisSamples.java
@@ -70,8 +70,7 @@ public class RedisSamples {
                 connectionStringSetting = "redisLocalhost",
                 key = "streamTest",
                 pollingIntervalInMs = 100,
-                maxBatchSize = 1,
-                deleteAfterProcess = true)
+                maxBatchSize = 1)
                 String entry,
             final ExecutionContext context) {
             context.getLogger().info(entry);

--- a/samples/node/StreamTrigger/function.json
+++ b/samples/node/StreamTrigger/function.json
@@ -2,7 +2,6 @@
   "bindings": [
     {
       "type": "redisStreamTrigger",
-      "deleteAfterProcess": false,
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,

--- a/samples/powershell/StreamTrigger/function.json
+++ b/samples/powershell/StreamTrigger/function.json
@@ -2,7 +2,6 @@
   "bindings": [
     {
       "type": "redisStreamTrigger",
-      "deleteAfterProcess": false,
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,

--- a/samples/python/StreamTrigger/function.json
+++ b/samples/python/StreamTrigger/function.json
@@ -2,7 +2,6 @@
   "bindings": [
     {
       "type": "redisStreamTrigger",
-      "deleteAfterProcess": false,
       "connectionStringSetting": "redisLocalhost",
       "key": "streamTest",
       "pollingIntervalInMs": 1000,

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
@@ -14,20 +14,16 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in ms.</param>
         /// <param name="maxBatchSize">Number of entries to pull from Redis at one time.</param>
-        /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool deleteAfterProcess = false)
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16)
         {
             ConnectionStringSetting = connectionStringSetting;
             Key = key;
             PollingIntervalInMs = pollingIntervalInMs;
             MaxBatchSize = maxBatchSize;
-            DeleteAfterProcess = deleteAfterProcess;
         }
 
         /// <summary>
-        /// Redis connection string setting.
         /// This setting will be used to resolve the actual connection string from the appsettings.
-        /// </summary>
         public string ConnectionStringSetting { get; }
 
         /// <summary>
@@ -44,10 +40,5 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         /// Number of entries to pull from Redis at one time.
         /// </summary>
         public int MaxBatchSize { get; }
-
-        /// <summary>
-        /// Decides if the function will delete the stream entries after processing.
-        /// </summary>
-        public bool DeleteAfterProcess { get; }
     }
 }

--- a/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.Functions.Worker.Extensions.Redis/RedisStreamTriggerAttribute.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Redis
         }
 
         /// <summary>
+        /// Redis connection string setting.
         /// This setting will be used to resolve the actual connection string from the appsettings.
+        /// </summary>
         public string ConnectionStringSetting { get; }
 
         /// <summary>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -15,15 +15,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     /// </summary>
     internal sealed class RedisStreamListener : RedisPollingTriggerBaseListener
     {
-        internal bool deleteAfterProcess;
         internal string consumerGroup;
         internal string consumerName;
 
-        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, string consumerGroup, bool deleteAfterProcess, ITriggeredFunctionExecutor executor, ILogger logger)
+        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, string consumerGroup, ITriggeredFunctionExecutor executor, ILogger logger)
             : base(name, connectionString, key, pollingInterval, maxBatchSize, executor, logger)
         {
             this.consumerGroup = consumerGroup;
-            this.deleteAfterProcess = deleteAfterProcess;
             this.consumerName = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") ?? Guid.NewGuid().ToString();
 
             this.logPrefix = $"[Name:{name}][Trigger:RedisStreamTrigger][ConsumerGroup:{consumerGroup}][Key:{key}][Consumer:{consumerName}]";
@@ -77,12 +75,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             RedisValue[] entryIds = new RedisValue[] { entry.Id };
             long acknowledged = await db.StreamAcknowledgeAsync(key, consumerGroup, entryIds);
             logger?.LogDebug($"{logPrefix} Acknowledged {acknowledged} entries from the stream at key '{key}'.");
-
-            if (deleteAfterProcess)
-            {
-                long deleted = await db.StreamDeleteAsync(key, entryIds);
-                logger?.LogDebug($"{logPrefix} Deleted {deleted} entries from the stream at key '{key}'.");
-            }
         }
 
         public async override void BeforeClosing()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
@@ -16,17 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 16</param>
-        /// <param name="deleteAfterProcess">Decides if the function will delete the stream entries after processing. Default: false</param>
-        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16, bool deleteAfterProcess = false)
+        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 10</param>
+        public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16)
             : base(connectionStringSetting, key, pollingIntervalInMs, maxBatchSize)
         {
-            DeleteAfterProcess = deleteAfterProcess;
         }
-
-        /// <summary>
-        /// Decides if the function will delete the stream entries after processing.
-        /// </summary>
-        public bool DeleteAfterProcess { get; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         /// <param name="connectionStringSetting">Redis connection string setting.</param>
         /// <param name="key">Key to read from.</param>
         /// <param name="pollingIntervalInMs">How often to poll Redis in milliseconds. Default: 1000</param>
-        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 10</param>
+        /// <param name="maxBatchSize">Number of entries to pull from a Redis stream at one time. Default: 16</param>
         public RedisStreamTriggerAttribute(string connectionStringSetting, string key, int pollingIntervalInMs = 1000, int maxBatchSize = 16)
             : base(connectionStringSetting, key, pollingIntervalInMs, maxBatchSize)
         {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
@@ -19,17 +19,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         private readonly TimeSpan pollingInterval;
         private readonly string key;
         private readonly int maxBatchSize;
-        private readonly bool deleteAfterProcess;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, bool deleteAfterProcess, Type parameterType, ILogger logger)
+        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, Type parameterType, ILogger logger)
         {
             this.connectionString = connectionString;
             this.key = key;
             this.pollingInterval = pollingInterval;
             this.maxBatchSize = maxBatchSize;
-            this.deleteAfterProcess = deleteAfterProcess;
             this.parameterType = parameterType;
             this.logger = logger;
         }
@@ -52,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, maxBatchSize, context.Descriptor.Id, deleteAfterProcess, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, maxBatchSize, context.Descriptor.Id, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
@@ -44,9 +44,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
             int maxBatchSize = attribute.MaxBatchSize;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
-            bool deleteAfterProcess = attribute.DeleteAfterProcess;
 
-            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, maxBatchSize, deleteAfterProcess, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, maxBatchSize, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
@@ -73,7 +73,7 @@ public @interface RedisListTrigger {
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */
-    int maxBatchSize() default 10;
+    int maxBatchSize() default 16;
 
     /**
      * Determines whether to pop entries from the beginning using LPOP or to pop entries from the end using RPOP.

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
@@ -73,11 +73,5 @@ public @interface RedisStreamTrigger {
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */
-    int maxBatchSize() default 10;
-
-    /**
-     * Whether the listener will delete the stream entries after the function runs.
-     * @return Whether the listener will delete the stream entries after the function runs.
-     */
-    boolean deleteAfterProcess() default false;
+    int maxBatchSize() default 16;
 }


### PR DESCRIPTION
Remove deleteAfterProcess parameter from StreamTrigger in favor of XDEL output command. XDEL is akin to binding functionality rather than trigger functionality, and now that output bindings are merged, we can simplify the StreamTrigger logic and remove overlap between triggers and bindings. Bindings also allow more flexibility, as it is possible to decide within the function based on the content of the stream entry if that entry should be deleted, whereas the streamTrigger deleteAfterProcess parameter does not give as much configurability.