### PR TITLE
Ensure all trigger connections use shared connectionMultiplexerCache

### DIFF
--- a/samples/dotnet/Properties/launchSettings.json
+++ b/samples/dotnet/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Microsoft.Azure.WebJobs.Extensions.Redis.Samples": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED": "1"
+      }
+    }
+  }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListListener.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     {
         internal bool listPopFromBeginning;
 
-        public RedisListListener(string name, string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, connectionString, key, pollingInterval, maxBatchSize, executor, logger)
+        public RedisListListener(string name, IConnectionMultiplexer multiplexer, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, multiplexer, key, pollingInterval, maxBatchSize, executor, logger)
         {
             this.listPopFromBeginning = listPopFromBeginning;
             this.logPrefix = $"[Name:{name}][Trigger:RedisListTrigger][Key:{key}]";

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     /// </summary>
     internal class RedisListTriggerBinding : ITriggerBinding
     {
-        private readonly string connectionString;
+        private readonly IConnectionMultiplexer multiplexer;
         private readonly TimeSpan pollingInterval;
         private readonly string key;
         private readonly int maxBatchSize;
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisListTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, Type parameterType, ILogger logger)
+        public RedisListTriggerBinding(IConnectionMultiplexer multiplexer, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, Type parameterType, ILogger logger)
         {
-            this.connectionString = connectionString;
+            this.multiplexer = multiplexer;
             this.key = key;
             this.pollingInterval = pollingInterval;
             this.maxBatchSize = maxBatchSize;
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisListListener(context.Descriptor.LogName, connectionString, key, pollingInterval, maxBatchSize, listPopFromBeginning, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisListListener(context.Descriptor.LogName, multiplexer, key, pollingInterval, maxBatchSize, listPopFromBeginning, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBindingProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -40,13 +41,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
+            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, attribute.ConnectionStringSetting);
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
             int maxBatchSize = attribute.MaxBatchSize;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
             bool listPopFromBeginning = attribute.ListPopFromBeginning;
 
-            return Task.FromResult<ITriggerBinding>(new RedisListTriggerBinding(connectionString, key, pollingInterval, maxBatchSize, listPopFromBeginning, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisListTriggerBinding(multiplexer, key, pollingInterval, maxBatchSize, listPopFromBeginning, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal IConnectionMultiplexer multiplexer;
         internal int maxBatchSize;
         internal string key;
+
         public RedisPollingTriggerBaseScaleMonitor(IConnectionMultiplexer multiplexer, int maxBatchSize, string key) 
         {
             this.multiplexer = multiplexer;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal IConnectionMultiplexer multiplexer;
         internal int maxBatchSize;
         internal string key;
-
         public RedisPollingTriggerBaseScaleMonitor(IConnectionMultiplexer multiplexer, int maxBatchSize, string key) 
         {
             this.multiplexer = multiplexer;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PubSubTrigger/RedisPubSubListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PubSubTrigger/RedisPubSubListener.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal ILogger logger;
         internal string logPrefix;
 
-
         public RedisPubSubListener(string name, IConnectionMultiplexer multiplexer, string channel, ITriggeredFunctionExecutor executor, ILogger logger)
         {
             this.multiplexer = multiplexer;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PubSubTrigger/RedisPubSubTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PubSubTrigger/RedisPubSubTriggerBinding.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     /// </summary>
     internal class RedisPubSubTriggerBinding : ITriggerBinding
     {
-        private readonly string connectionString;
+        private readonly IConnectionMultiplexer multiplexer;
         private readonly string channel;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisPubSubTriggerBinding(string connectionString, string channel, Type parameterType, ILogger logger)
+        public RedisPubSubTriggerBinding(IConnectionMultiplexer multiplexer, string channel, Type parameterType, ILogger logger)
         {
-            this.connectionString = connectionString;
+            this.multiplexer = multiplexer;
             this.channel = channel;
             this.parameterType = parameterType;
             this.logger = logger;
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisPubSubListener(context.Descriptor.LogName, connectionString, channel, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisPubSubListener(context.Descriptor.LogName, multiplexer, channel, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PubSubTrigger/RedisPubSubTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PubSubTrigger/RedisPubSubTriggerBindingProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -40,10 +41,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
+            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, attribute.ConnectionStringSetting);
             string channel = RedisUtilities.ResolveString(nameResolver, attribute.Channel, nameof(attribute.Channel));
 
-            return Task.FromResult<ITriggerBinding>(new RedisPubSubTriggerBinding(connectionString, channel, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisPubSubTriggerBinding(multiplexer, channel, parameter.ParameterType, logger));
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal string consumerGroup;
         internal string consumerName;
 
-        public RedisStreamListener(string name, string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, string consumerGroup, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, connectionString, key, pollingInterval, maxBatchSize, executor, logger)
+        public RedisStreamListener(string name, IConnectionMultiplexer multiplexer, string key, TimeSpan pollingInterval, int maxBatchSize, string consumerGroup, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, multiplexer, key, pollingInterval, maxBatchSize, executor, logger)
         {
             this.consumerGroup = consumerGroup;
             this.consumerName = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") ?? Guid.NewGuid().ToString();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
@@ -15,16 +15,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     /// </summary>
     internal class RedisStreamTriggerBinding : ITriggerBinding
     {
-        private readonly string connectionString;
+        private readonly IConnectionMultiplexer multiplexer;
         private readonly TimeSpan pollingInterval;
         private readonly string key;
         private readonly int maxBatchSize;
         private readonly Type parameterType;
         private readonly ILogger logger;
 
-        public RedisStreamTriggerBinding(string connectionString, string key, TimeSpan pollingInterval, int maxBatchSize, Type parameterType, ILogger logger)
+        public RedisStreamTriggerBinding(IConnectionMultiplexer multiplexer, string key, TimeSpan pollingInterval, int maxBatchSize, Type parameterType, ILogger logger)
         {
-            this.connectionString = connectionString;
+            this.multiplexer = multiplexer;
             this.key = key;
             this.pollingInterval = pollingInterval;
             this.maxBatchSize = maxBatchSize;
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, connectionString, key, pollingInterval, maxBatchSize, context.Descriptor.Id, context.Executor, logger));
+            return Task.FromResult<IListener>(new RedisStreamListener(context.Descriptor.LogName, multiplexer, key, pollingInterval, maxBatchSize, context.Descriptor.Id, context.Executor, logger));
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBindingProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 using System;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -40,12 +41,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 return Task.FromResult<ITriggerBinding>(null);
             }
 
-            string connectionString = RedisUtilities.ResolveConnectionString(configuration, attribute.ConnectionStringSetting);
+            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, attribute.ConnectionStringSetting);
             string key = RedisUtilities.ResolveString(nameResolver, attribute.Key, nameof(attribute.Key));
             int maxBatchSize = attribute.MaxBatchSize;
             TimeSpan pollingInterval = TimeSpan.FromMilliseconds(attribute.PollingIntervalInMs);
 
-            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(connectionString, key, pollingInterval, maxBatchSize, parameter.ParameterType, logger));
+            return Task.FromResult<ITriggerBinding>(new RedisStreamTriggerBinding(multiplexer, key, pollingInterval, maxBatchSize, parameter.ParameterType, logger));
         }
     }
 }

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -109,5 +109,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
         {
             return value.GetType().FullName + ":" + JsonConvert.SerializeObject(value);
         }
+
+        internal class ScaleStatus
+        {
+            public int vote;
+            public int targetWorkerCount;
+        }
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -107,34 +107,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
 
-        [Fact]
-        public async void ListTrigger_TargetBasedScaling_E2EValidation()
-        {
-            string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
-            int port = 7071;
-            int elements = 10000;
-            RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
+        //[Fact]
+        //public async void ListTrigger_TargetBasedScaling_E2EValidation()
+        //{
+        //    string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
+        //    int port = 7071;
+        //    int elements = 10000;
+        //    RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
 
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
-            {
-                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
-                await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
-                await multiplexer.CloseAsync();
-            };
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+        //    {
+        //        await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+        //        await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
+        //        await multiplexer.CloseAsync();
+        //    };
 
-            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-            using (HttpClient client = new HttpClient())
-            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-            {
-                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-                functionsProcess.Kill();
-            };
+        //    IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+        //    using (HttpClient client = new HttpClient())
+        //    using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+        //    {
+        //        StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+        //        HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+        //        status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+        //        functionsProcess.Kill();
+        //    };
 
-            Assert.Equal(1, status.vote);
-            Assert.True(status.targetWorkerCount / (float)elements > 0.999);
-        }
+        //    Assert.Equal(1, status.vote);
+        //    Assert.True(status.targetWorkerCount / (float)elements > 0.999);
+        //}
     }
 }

--- a/test/dotnet/Integration/RedisListTriggerTests.cs
+++ b/test/dotnet/Integration/RedisListTriggerTests.cs
@@ -107,36 +107,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
 
-        //Target Scaler Integration Tests not required.
-        // Keeping this as a manual test for local development.
-        //[Fact]
-        //public async void ListTrigger_TargetBasedScaling_WorksCorrectly()
-        //{
-        //    string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
-        //    int port = 7071;
-        //    int elements = 10000;
-        //    RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
+        [Fact]
+        public async void ListTrigger_TargetBasedScaling_E2EValidation()
+        {
+            string functionName = nameof(RedisListTriggerTestFunctions.ListTrigger_RedisValue_LongPollingInterval);
+            int port = 7071;
+            int elements = 10000;
+            RedisValue[] valuesArray = Enumerable.Range(0, elements).Select(x => new RedisValue(x.ToString())).ToArray();
 
-        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
-        //    {
-        //        await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
-        //        await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
-        //        await multiplexer.CloseAsync();
-        //    };
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisListTriggerTestFunctions.localhostSetting)))
+            {
+                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+                await multiplexer.GetDatabase().ListLeftPushAsync(functionName, valuesArray);
+                await multiplexer.CloseAsync();
+            };
 
-        //    IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
-        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-        //    using (HttpClient client = new HttpClient())
-        //    using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-        //    {
-        //        StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-        //        HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-        //        status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-        //        functionsProcess.Kill();
-        //    };
+            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+            using (HttpClient client = new HttpClient())
+            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+            {
+                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+                functionsProcess.Kill();
+            };
 
-        //    Assert.Equal(1, status.vote);
-        //    Assert.True(status.targetWorkerCount / (float) elements > 0.999);
-        //}
+            Assert.Equal(1, status.vote);
+            Assert.True(status.targetWorkerCount / (float)elements > 0.999);
+        }
     }
 }

--- a/test/dotnet/Integration/RedisStreamTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisStreamTriggerTestFunctions.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     public static class RedisStreamTriggerTestFunctions
     {
         public const string localhostSetting = "redisLocalhost";
-        public const int pollingInterval = 100;
-        public const int batchSize = 100;
+        public const int pollingIntervalShort = 100;
+        public const int pollingIntervalLong = 10000;
 
         [FunctionName(nameof(StreamTrigger_StreamEntry))]
         public static void StreamTrigger_StreamEntry(
-            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_StreamEntry), pollingIntervalInMs: pollingInterval)] StreamEntry entry,
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_StreamEntry), pollingIntervalInMs: pollingIntervalShort)] StreamEntry entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(StreamTrigger_NameValueEntryArray))]
         public static void StreamTrigger_NameValueEntryArray(
-            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_NameValueEntryArray), pollingIntervalInMs: pollingInterval)] NameValueEntry[] values,
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_NameValueEntryArray), pollingIntervalInMs: pollingIntervalShort)] NameValueEntry[] values,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(values));
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(StreamTrigger_Dictionary))]
         public static void StreamTrigger_Dictionary(
-            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_Dictionary), pollingIntervalInMs: pollingInterval)] Dictionary<string, string> values,
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_Dictionary), pollingIntervalInMs: pollingIntervalShort)] Dictionary<string, string> values,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(values));
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(StreamTrigger_ByteArray))]
         public static void StreamTrigger_ByteArray(
-            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_ByteArray), pollingIntervalInMs: pollingInterval)] byte[] values,
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_ByteArray), pollingIntervalInMs: pollingIntervalShort)] byte[] values,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(values));
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(StreamTrigger_String))]
         public static void StreamTrigger_String(
-            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_String), pollingIntervalInMs: pollingInterval)] string values,
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_String), pollingIntervalInMs: pollingIntervalShort)] string values,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(values));
@@ -52,10 +52,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 
         [FunctionName(nameof(StreamTrigger_CustomType))]
         public static void StreamTrigger_CustomType(
-            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_CustomType), pollingIntervalInMs: pollingInterval)] CustomType entry,
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_CustomType), pollingIntervalInMs: pollingIntervalShort)] CustomType entry,
             ILogger logger)
         {
             logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
         }
+
+        [FunctionName(nameof(StreamTrigger_RedisValue_LongPollingInterval))]
+        public static void StreamTrigger_RedisValue_LongPollingInterval(
+            [RedisStreamTrigger(localhostSetting, nameof(StreamTrigger_RedisValue_LongPollingInterval), pollingIntervalInMs: pollingIntervalLong, maxBatchSize: 1)] RedisValue entry,
+            ILogger logger)
+        {
+            logger.LogInformation(IntegrationTestHelpers.GetLogValue(entry));
+        }
+
     }
 }

--- a/test/dotnet/Integration/RedisStreamTriggerTests.cs
+++ b/test/dotnet/Integration/RedisStreamTriggerTests.cs
@@ -130,37 +130,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
 
+        //[Fact]
+        //public async void StreamTrigger_TargetBasedScaling_E2EValidation()
+        //{
+        //    string functionName = nameof(RedisStreamTriggerTestFunctions.StreamTrigger_RedisValue_LongPollingInterval);
+        //    int port = 7071;
+        //    int elements = 10000;
 
-        [Fact]
-        public async void StreamTrigger_TargetBasedScaling_E2EValidation()
-        {
-            string functionName = nameof(RedisStreamTriggerTestFunctions.StreamTrigger_RedisValue_LongPollingInterval);
-            int port = 7071;
-            int elements = 10000;
+        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisStreamTriggerTestFunctions.localhostSetting)))
+        //    {
+        //        await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+        //        for(int i = 0; i < elements; i++)
+        //        {
+        //            await multiplexer.GetDatabase().StreamAddAsync(functionName, i, i);
+        //        }
+        //        await multiplexer.CloseAsync();
+        //    };
 
-            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisStreamTriggerTestFunctions.localhostSetting)))
-            {
-                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
-                for(int i = 0; i < elements; i++)
-                {
-                    await multiplexer.GetDatabase().StreamAddAsync(functionName, i, i);
-                }
-                await multiplexer.CloseAsync();
-            };
+        //    IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+        //    using (HttpClient client = new HttpClient())
+        //    using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+        //    {
+        //        StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+        //        HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+        //        status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+        //        functionsProcess.Kill();
+        //    };
 
-            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
-            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-            using (HttpClient client = new HttpClient())
-            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-            {
-                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-                functionsProcess.Kill();
-            };
-
-            Assert.Equal(1, status.vote);
-            Assert.True(status.targetWorkerCount / (float)elements > 0.999);
-        }
+        //    Assert.Equal(1, status.vote);
+        //    Assert.True(status.targetWorkerCount / (float)elements > 0.999);
+        //}
     }
 }

--- a/test/dotnet/Integration/RedisStreamTriggerTests.cs
+++ b/test/dotnet/Integration/RedisStreamTriggerTests.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using Newtonsoft.Json;
 using System.Threading.Tasks;
 using Xunit;
+using System.Net.Http;
+using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 {
@@ -126,6 +128,39 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             };
             var incorrect = counts.Where(pair => pair.Value != 0);
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
+        }
+
+
+        [Fact]
+        public async void StreamTrigger_TargetBasedScaling_E2EValidation()
+        {
+            string functionName = nameof(RedisStreamTriggerTestFunctions.StreamTrigger_RedisValue_LongPollingInterval);
+            int port = 7071;
+            int elements = 10000;
+
+            using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, RedisStreamTriggerTestFunctions.localhostSetting)))
+            {
+                await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
+                for(int i = 0; i < elements; i++)
+                {
+                    await multiplexer.GetDatabase().StreamAddAsync(functionName, i, i);
+                }
+                await multiplexer.CloseAsync();
+            };
+
+            IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
+            using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
+            using (HttpClient client = new HttpClient())
+            using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
+            {
+                StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
+                HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
+                status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
+                functionsProcess.Kill();
+            };
+
+            Assert.Equal(1, status.vote);
+            Assert.True(status.targetWorkerCount / (float)elements > 0.999);
         }
     }
 }

--- a/test/dotnet/Unit/RedisPollingTriggerBaseScaleMonitorTests.cs
+++ b/test/dotnet/Unit/RedisPollingTriggerBaseScaleMonitorTests.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [Fact]
         public async void StartAsync_CreatesConnectionMultiplexerAsync()
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, defaultBatchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, defaultBatchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             await listener.StartAsync(new CancellationToken());
             Assert.NotNull(listener.multiplexer);
             Assert.Equal(connectionString, listener.multiplexer.Configuration, ignoreCase: true);
@@ -76,7 +77,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [Fact]
         public async void StopAsync_ClosesAndDisposesConnectionMultiplexerAsync()
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, defaultBatchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, defaultBatchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             listener.multiplexer = A.Fake<IConnectionMultiplexer>();
             await listener.StopAsync(new CancellationToken());
             A.CallTo(() => listener.multiplexer.CloseAsync(A<bool>._)).MustHaveHappened();
@@ -92,7 +94,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(5, 20, ScaleVote.ScaleIn)]
         public void ScalingLogic_ConstantMetrics(int workerCount, int batchSize, ScaleVote expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = constantMetrics };
             Assert.Equal(expected, listener.GetMonitor().GetScaleStatus(context).Vote);
         }
@@ -106,7 +109,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(5, 20)]
         public void ScalingLogic_FewMetrics(int workerCount, int batchSize)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = fewMetrics };
             Assert.Equal(ScaleVote.None, listener.GetMonitor().GetScaleStatus(context).Vote);
         }
@@ -118,7 +122,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(10, 10, ScaleVote.ScaleIn)]
         public void ScalingLogic_DecreasingMetrics(int workerCount, int batchSize, ScaleVote expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = decreasingMetrics };
             Assert.Equal(expected, listener.GetMonitor().GetScaleStatus(context).Vote);
         }
@@ -130,7 +135,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(10, 10, ScaleVote.ScaleIn)]
         public void ScalingLogic_IncreasingMetrics(int workerCount, int batchSize, ScaleVote expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = increasingMetrics };
             Assert.Equal(expected, listener.GetMonitor().GetScaleStatus(context).Vote);
         }
@@ -145,7 +151,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(10000, 10, 1000)]
         public async Task TargetScaler_IncreasingMetricsAsync(long remaining, int batchSize, int expected)
         {
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, connectionString, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             IDatabase fakeDatabase = A.Fake<IDatabase>();
             A.CallTo(() => fakeDatabase.ListLength(A<RedisKey>._, A<CommandFlags>._)).Returns(remaining);
             IConnectionMultiplexer fakeMultiplexer = A.Fake<IConnectionMultiplexer>();

--- a/test/dotnet/Unit/RedisPubSubListenerTests.cs
+++ b/test/dotnet/Unit/RedisPubSubListenerTests.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [Fact]
         public async void StartAsync_CreatesConnectionMultiplexer()
         {
-            RedisPubSubListener listener = new RedisPubSubListener(id, connectionString, channel, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPubSubListener listener = new RedisPubSubListener(id, multiplexer, channel, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             await listener.StartAsync(new CancellationToken());
             Assert.NotNull(listener.multiplexer);
             Assert.Equal(connectionString, listener.multiplexer.Configuration, ignoreCase: true);
@@ -25,7 +26,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [Fact]
         public async void StopAsync_ClosesAndDisposesConnectionMultiplexer()
         {
-            RedisPubSubListener listener = new RedisPubSubListener(id, connectionString, channel, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            IConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(connectionString);
+            RedisPubSubListener listener = new RedisPubSubListener(id, multiplexer, channel, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
             listener.multiplexer = A.Fake<IConnectionMultiplexer>();
             await listener.StopAsync(new CancellationToken());
             A.CallTo(() => listener.multiplexer.CloseAsync(A<bool>._)).MustHaveHappened();


### PR DESCRIPTION
Ensure all connections are through the shared connectionMuliplexerCache in the RedisExtensionConfigProvider.

Previously, the multiplexer given to the ScalerProviders was disposed early, causing scaling to fail with the exception:
```
Microsoft.Azure.WebJobs.Extensions.Redis: Object reference not set to an instance of an object.
Failed to query scale result for target scaler.
```