### PR TITLE
Update Stream Trigger Scaling logic

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting, context.Descriptor.ShortName);
 
             return Task.FromResult<IListener>(new RedisListListener(
-                context.Descriptor.LogName,
+                context.Descriptor.ShortName,
                 multiplexer,
                 key,
                 pollingInterval,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerScaleMonitor.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             string name,
             int maxBatchSize,
             string key) 
-            : base(multiplexer, maxBatchSize, key)
+            : base(name, multiplexer, maxBatchSize, key)
         {
-            this.Descriptor = new ScaleMonitorDescriptor(name, $"{name}-RedisListTrigger-{key}");
-            this.TargetScalerDescriptor = new TargetScalerDescriptor($"{name}-RedisListTrigger-{key}");
+            this.Descriptor = new ScaleMonitorDescriptor(name, RedisScalerProvider.GetFunctionScalerId(name, "RedisListTrigger", key));
+            this.TargetScalerDescriptor = new TargetScalerDescriptor(RedisScalerProvider.GetFunctionScalerId(name, "RedisListTrigger", key));
         }
 
         public override Task<RedisPollingTriggerBaseMetrics> GetMetricsAsync()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
@@ -10,12 +10,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     {
         private const int MINIMUM_SAMPLES = 5;
 
+        internal string name;
         internal IConnectionMultiplexer multiplexer;
         internal int maxBatchSize;
         internal string key;
 
-        public RedisPollingTriggerBaseScaleMonitor(IConnectionMultiplexer multiplexer, int maxBatchSize, string key) 
+        public RedisPollingTriggerBaseScaleMonitor(string name, IConnectionMultiplexer multiplexer, int maxBatchSize, string key)
         {
+            this.name = name;
             this.multiplexer = multiplexer;
             this.maxBatchSize = maxBatchSize;
             this.key = key;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         public async Task<TargetScalerResult> GetScaleResultAsync(TargetScalerContext context)
         {
             RedisPollingTriggerBaseMetrics metric = await GetMetricsAsync();
-            return new TargetScalerResult() { TargetWorkerCount = (int)Math.Ceiling(metric.Remaining / (decimal)maxBatchSize) };
+            return new TargetScalerResult() { TargetWorkerCount = (int)Math.Ceiling(metric.Remaining / (double)maxBatchSize) };
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisScalerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisScalerProvider.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             }
         }
 
+        public static string GetFunctionScalerId(string name, string type, string key) => $"{name}-{type}-{key}";
+
         public class RedisPollingTriggerMetadata
         {
             [JsonProperty]

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                     logger?.LogCritical($"{logPrefix} Could not create consumer group '{name}' for the stream at key '{key}'.");
                     throw new Exception($"Could not create consumer group '{name}' for the stream at key '{key}'.");
                 }
+                await db.KeyDeleteAsync(entriesReadKey);
                 logger?.LogInformation($"{logPrefix} Successfully created consumer group '{name}' for the stream at key '{key}'.");
 
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -80,16 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         {
             IDatabase db = multiplexer.GetDatabase();
             await executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = value }, cancellationToken);
-
             long acknowledged = await db.StreamAcknowledgeAsync(key, name, value.Id);
-
-            // Redis 6/6.2 has no way to estimate number of entries read by the group, whereas Redis 7 contains entries_read and lag fields in the XINFO GROUPS command
-            // This is necessary for the scale controller to accurately estimate the number of function instances needed to process unacked entries.
-            if (serverVersion < RedisUtilities.Version70)
-            {
-                await db.StringIncrementAsync(entriesReadKey, acknowledged);
-            }
-
             logger?.LogDebug($"{logPrefix} Acknowledged {acknowledged} entries from the stream at key '{key}'.");
         }
 
@@ -97,16 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         {
             IDatabase db = multiplexer.GetDatabase();
             await executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = values }, cancellationToken);
-
             long acknowledged = await db.StreamAcknowledgeAsync(key, name, Array.ConvertAll(values, value => value.Id));
-
-            // Redis 6/6.2 has no way to estimate number of entries read by the group, whereas Redis 7 contains entries_read and lag fields in the XINFO GROUPS command
-            // This is necessary for the scale controller to accurately estimate the number of function instances needed to process unacked entries.
-            if (serverVersion < RedisUtilities.Version70)
-            {
-                await db.StringIncrementAsync(entriesReadKey, acknowledged);
-            }
-
             logger?.LogDebug($"{logPrefix} Acknowledged {acknowledged} entries from the stream at key '{key}'.");
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             // This is necessary for the scale controller to accurately estimate the number of function instances needed to process unacked entries.
             if (serverVersion < RedisUtilities.Version70)
             {
-                await db.StringIncrementAsync(entriesReadKey);
+                await db.StringIncrementAsync(entriesReadKey, acknowledged);
             }
 
             logger?.LogDebug($"{logPrefix} Acknowledged {acknowledged} entries from the stream at key '{key}'.");
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             // This is necessary for the scale controller to accurately estimate the number of function instances needed to process unacked entries.
             if (serverVersion < RedisUtilities.Version70)
             {
-                await db.StringIncrementAsync(entriesReadKey);
+                await db.StringIncrementAsync(entriesReadKey, acknowledged);
             }
 
             logger?.LogDebug($"{logPrefix} Acknowledged {acknowledged} entries from the stream at key '{key}'.");

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -83,6 +83,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
             long acknowledged = await db.StreamAcknowledgeAsync(key, name, value.Id);
 
+            // Redis 6/6.2 has no way to estimate number of entries read by the group, whereas Redis 7 contains entries_read and lag fields in the XINFO GROUPS command
+            // This is necessary for the scale controller to accurately estimate the number of function instances needed to process unacked entries.
             if (serverVersion < RedisUtilities.Version70)
             {
                 await db.StringIncrementAsync(entriesReadKey);
@@ -99,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             long acknowledged = await db.StreamAcknowledgeAsync(key, name, Array.ConvertAll(values, value => value.Id));
 
             // Redis 6/6.2 has no way to estimate number of entries read by the group, whereas Redis 7 contains entries_read and lag fields in the XINFO GROUPS command
-            // This is necessary for the scale controller to accurately estimate the number of function instances needed to process messages.
+            // This is necessary for the scale controller to accurately estimate the number of function instances needed to process unacked entries.
             if (serverVersion < RedisUtilities.Version70)
             {
                 await db.StringIncrementAsync(entriesReadKey);

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
@@ -70,7 +70,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 pollingInterval,
                 maxBatchSize,
                 IsBatchParameter(),
-                context.Descriptor.Id,
                 context.Executor,
                 logger));
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Scale;
 using StackExchange.Redis;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis
@@ -11,21 +12,34 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             string name,
             int maxBatchSize,
             string key) 
-            : base(multiplexer, maxBatchSize, key)
+            : base(name, multiplexer, maxBatchSize, key)
         {
-            this.Descriptor = new ScaleMonitorDescriptor(name, $"{name}-RedisStreamTrigger-{key}");
-            this.TargetScalerDescriptor = new TargetScalerDescriptor($"{name}-RedisStreamTrigger-{key}");
+            this.Descriptor = new ScaleMonitorDescriptor(name, RedisScalerProvider.GetFunctionScalerId(name, "RedisStreamTrigger", key));
+            this.TargetScalerDescriptor = new TargetScalerDescriptor(RedisScalerProvider.GetFunctionScalerId(name, "RedisStreamTrigger", key));
         }
 
-        public override Task<RedisPollingTriggerBaseMetrics> GetMetricsAsync()
+        public override async Task<RedisPollingTriggerBaseMetrics> GetMetricsAsync()
         {
-            var metrics = new RedisPollingTriggerBaseMetrics
+            long entriesRemaining = 0;
+            if (multiplexer.GetServers()[0].Version <= RedisUtilities.Version70)
             {
-                Remaining = multiplexer.GetDatabase().StreamLength(key),
+                StreamGroupInfo[] groups = multiplexer.GetDatabase().StreamGroupInfo(key);
+                entriesRemaining = groups.Where(group => group.Name == name).First().Lag ?? 0;
+            }
+            else
+            {
+                long length = await multiplexer.GetDatabase().StreamLengthAsync(key);
+                long processed = (long) await multiplexer.GetDatabase().StringGetAsync(RedisScalerProvider.GetFunctionScalerId(name, "RedisStreamTrigger", key));
+                entriesRemaining = length - processed;
+            }
+
+            RedisPollingTriggerBaseMetrics metrics = new RedisPollingTriggerBaseMetrics
+            {
+                Remaining = entriesRemaining,
                 Timestamp = DateTime.UtcNow,
             };
 
-            return Task.FromResult(metrics);
+            return metrics;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
@@ -71,18 +71,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             string[] firstIdSplit = firstId.Split('-');
             string[] lastIdSplit = lastId.Split('-');
             string[] lastDeliveredIdSplit = lastDeliveredId.Split('-');
-            long firstTimestamp = long.Parse(firstIdSplit[0]);
-            long lastTimestamp = long.Parse(lastIdSplit[0]);
-            long lastDeliveredTimestamp = long.Parse(lastDeliveredIdSplit[0]);
+            ulong firstTimestamp = ulong.Parse(firstIdSplit[0]);
+            ulong lastTimestamp = ulong.Parse(lastIdSplit[0]);
+            ulong lastDeliveredTimestamp = ulong.Parse(lastDeliveredIdSplit[0]);
 
             if (lastTimestamp == lastDeliveredTimestamp)
             {
                 // If timestamp is the same, return counter difference
-                long lastCounter = long.Parse(lastIdSplit[1]);
-                long lastDelieveredCoutner = long.Parse(lastDeliveredIdSplit[1]);
+                ulong lastCounter = ulong.Parse(lastIdSplit[1]);
+                ulong lastDelieveredCoutner = ulong.Parse(lastDeliveredIdSplit[1]);
                 return new RedisPollingTriggerBaseMetrics
                 {
-                    Remaining = Math.Min(streamLength, Math.Max(1, lastCounter - lastDelieveredCoutner)),
+                    Remaining = Math.Min(streamLength, (long)Math.Max(1, lastCounter - lastDelieveredCoutner)),
                     Timestamp = DateTime.UtcNow,
                 };
             }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             if (multiplexer.GetServers()[0].Version >= RedisUtilities.Version70 && group.Lag.HasValue)
             {
                 // Redis 7: Scaler gets number of remaining entries for the consumer group from XINFO GROUPS.
-                new RedisPollingTriggerBaseMetrics
+                return new RedisPollingTriggerBaseMetrics
                 {
                     Remaining = group.Lag.Value,
                     Timestamp = DateTime.UtcNow,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
@@ -88,9 +88,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             }
 
             // Assume percentage of time processsed as percentage of entries processed
-            decimal timeRemaining = Math.Max(1, lastTimestamp - lastDeliveredTimestamp);
-            decimal timeTotal = Math.Max(1, lastTimestamp - firstTimestamp);
-            decimal percentageRemaining = timeRemaining / timeTotal;
+            double timeRemaining = Math.Max(1, lastTimestamp - lastDeliveredTimestamp);
+            double timeTotal = Math.Max(1, lastTimestamp - firstTimestamp);
+            double percentageRemaining = timeRemaining / timeTotal;
             long estimatedRemaining = (long) Math.Min(streamLength, Math.Max(1, percentageRemaining * streamLength));
             return new RedisPollingTriggerBaseMetrics
             {

--- a/test/dotnet/Integration/IntegrationTestHelpers.cs
+++ b/test/dotnet/Integration/IntegrationTestHelpers.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
     internal static class IntegrationTestHelpers
     {
         internal const string connectionStringSetting = "redisConnectionString";
-        internal static string Redis60 = "/redis/redis-6.0.20";
-        internal static string Redis62 = "/redis/redis-6.2.14";
-        internal static string Redis70 = "/redis/redis-7.0.14";
+        internal const string Redis60 = "/redis/redis-6.0.20";
+        internal const string Redis62 = "/redis/redis-6.2.14";
+        internal const string Redis70 = "/redis/redis-7.0.14";
 
         internal static Process StartFunction(string functionName, int port)
         {

--- a/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
@@ -3,7 +3,7 @@ using StackExchange.Redis;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 {
-    public static class RedisListTriggerTestFunctions
+    public class RedisListTriggerTestFunctions
     {
         public const int pollingIntervalShort = 100;
         public const int pollingIntervalLong = 10000;

--- a/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
+++ b/test/dotnet/Integration/RedisListTriggerTestFunctions.cs
@@ -3,7 +3,7 @@ using StackExchange.Redis;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
 {
-    public class RedisListTriggerTestFunctions
+    public static class RedisListTriggerTestFunctions
     {
         public const int pollingIntervalShort = 100;
         public const int pollingIntervalLong = 10000;

--- a/test/dotnet/Integration/RedisScalerProviderTests.cs
+++ b/test/dotnet/Integration/RedisScalerProviderTests.cs
@@ -62,7 +62,11 @@ $@"{{
         }
 
         [Theory]
+        [InlineData(listTrigger, 0, 0)]
+        [InlineData(listTrigger, 1, 1)]
         [InlineData(listTrigger, 100, 10)]
+        [InlineData(streamTrigger, 0, 0)]
+        [InlineData(streamTrigger, 1, 1)]
         [InlineData(streamTrigger, 100, 10)]
         public async Task ScaleHostEndToEndTest(string triggerJson, int elements, int expectedTarget)
         {
@@ -98,17 +102,14 @@ $@"{{
                 IntegrationTestHelpers.StopRedis(redisProcess);
                 multiplexer.Close();
             }
-            Assert.Equal(ScaleVote.ScaleOut, scaleStatus.Vote);
             Assert.Equal(expectedTarget, scaleStatus.TargetWorkerCount);
         }
 
 
         [Theory]
         [InlineData(IntegrationTestHelpers.Redis60, 100, 0)]
-        [InlineData(IntegrationTestHelpers.Redis60, 50, 50)]
         [InlineData(IntegrationTestHelpers.Redis60, 0, 100)]
         [InlineData(IntegrationTestHelpers.Redis62, 100, 0)]
-        [InlineData(IntegrationTestHelpers.Redis62, 50, 50)]
         [InlineData(IntegrationTestHelpers.Redis62, 0, 100)]
         [InlineData(IntegrationTestHelpers.Redis70, 100, 0)]
         [InlineData(IntegrationTestHelpers.Redis70, 50, 50)]
@@ -121,7 +122,7 @@ $@"{{
 
             AggregateScaleStatus scaleStatus;
             long streamLength;
-            using (Process redisProcess = IntegrationTestHelpers.StartRedis(redisVersion))
+            //using (Process redisProcess = IntegrationTestHelpers.StartRedis(redisVersion))
             using (IHost scaleHost = await CreateScaleHostAsync(triggerMetadata))
             using (ConnectionMultiplexer multiplexer = await ConnectionMultiplexer.ConnectAsync(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, IntegrationTestHelpers.connectionStringSetting)))
             {
@@ -145,7 +146,7 @@ $@"{{
                 IScaleStatusProvider scaleStatusProvider = scaleHost.Services.GetService<IScaleStatusProvider>();
                 scaleStatus = await scaleStatusProvider.GetScaleStatusAsync(new ScaleStatusContext());
                 await scaleHost.StopAsync();
-                IntegrationTestHelpers.StopRedis(redisProcess);
+                //IntegrationTestHelpers.StopRedis(redisProcess);
             }
             Assert.Equal(processed + unprocessed, streamLength);
             Assert.Equal(unprocessed / RedisStreamTriggerTestFunctions.batchSize, scaleStatus.TargetWorkerCount);

--- a/test/dotnet/Integration/RedisScalerProviderTests.cs
+++ b/test/dotnet/Integration/RedisScalerProviderTests.cs
@@ -80,7 +80,6 @@ $@"{{
             {
                 await multiplexer.GetDatabase().KeyDeleteAsync(redisMetadata.key);
 
-
                 // add some messages
                 if (triggerMetadata.Type.Equals("redisListTrigger"))
                 {
@@ -97,14 +96,12 @@ $@"{{
 
                 IScaleStatusProvider scaleStatusProvider = scaleHost.Services.GetService<IScaleStatusProvider>();
                 scaleStatus = await scaleStatusProvider.GetScaleStatusAsync(new ScaleStatusContext());
-
                 await scaleHost.StopAsync();
                 IntegrationTestHelpers.StopRedis(redisProcess);
                 multiplexer.Close();
             }
             Assert.Equal(expectedTarget, scaleStatus.TargetWorkerCount);
         }
-
 
         [Theory]
         [InlineData(IntegrationTestHelpers.Redis60, 100, 0)]

--- a/test/dotnet/Integration/RedisScalerProviderTests.cs
+++ b/test/dotnet/Integration/RedisScalerProviderTests.cs
@@ -122,7 +122,7 @@ $@"{{
 
             AggregateScaleStatus scaleStatus;
             long streamLength;
-            //using (Process redisProcess = IntegrationTestHelpers.StartRedis(redisVersion))
+            using (Process redisProcess = IntegrationTestHelpers.StartRedis(redisVersion))
             using (IHost scaleHost = await CreateScaleHostAsync(triggerMetadata))
             using (ConnectionMultiplexer multiplexer = await ConnectionMultiplexer.ConnectAsync(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, IntegrationTestHelpers.connectionStringSetting)))
             {
@@ -146,7 +146,7 @@ $@"{{
                 IScaleStatusProvider scaleStatusProvider = scaleHost.Services.GetService<IScaleStatusProvider>();
                 scaleStatus = await scaleStatusProvider.GetScaleStatusAsync(new ScaleStatusContext());
                 await scaleHost.StopAsync();
-                //IntegrationTestHelpers.StopRedis(redisProcess);
+                IntegrationTestHelpers.StopRedis(redisProcess);
             }
             Assert.Equal(processed + unprocessed, streamLength);
             Assert.Equal(unprocessed / RedisStreamTriggerTestFunctions.batchSize, scaleStatus.TargetWorkerCount);

--- a/test/dotnet/Integration/RedisStreamTriggerTests.cs
+++ b/test/dotnet/Integration/RedisStreamTriggerTests.cs
@@ -170,37 +170,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Integration
             var incorrect = counts.Where(pair => pair.Value != 0);
             Assert.False(incorrect.Any(), JsonConvert.SerializeObject(incorrect));
         }
-        
-        //[Fact]
-        //public async void StreamTrigger_TargetBasedScaling_E2EValidation()
-        //{
-        //    string functionName = nameof(RedisStreamTriggerTestFunctions.StreamTrigger_RedisValue_LongPollingInterval);
-        //    int port = 7071;
-        //    int elements = 10000;
-
-        //    using (ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(RedisUtilities.ResolveConnectionString(IntegrationTestHelpers.localsettings, IntegrationTestHelpers.connectionStringSetting)))
-        //    {
-        //        await multiplexer.GetDatabase().KeyDeleteAsync(functionName);
-        //        for(int i = 0; i < elements; i++)
-        //        {
-        //            await multiplexer.GetDatabase().StreamAddAsync(functionName, i, i);
-        //        }
-        //        await multiplexer.CloseAsync();
-        //    };
-
-        //    IntegrationTestHelpers.ScaleStatus status = new IntegrationTestHelpers.ScaleStatus { vote = 0, targetWorkerCount = 0 };
-        //    using (Process functionsProcess = IntegrationTestHelpers.StartFunction(functionName, port))
-        //    using (HttpClient client = new HttpClient())
-        //    using (StringContent jsonContent = new StringContent("{}", Encoding.UTF8, "application/json"))
-        //    {
-        //        StringContent content = new StringContent(JsonConvert.SerializeObject(new { name = functionName, arguments = new string[] { "1" } }));
-        //        HttpResponseMessage response = await client.PostAsync($"http://127.0.0.1:{port}/admin/host/scale/status", jsonContent);
-        //        status = JsonConvert.DeserializeObject<IntegrationTestHelpers.ScaleStatus>(await response.Content.ReadAsStringAsync());
-        //        functionsProcess.Kill();
-        //    };
-
-        //    Assert.Equal(1, status.vote);
-        //    Assert.True(status.targetWorkerCount / (float)elements > 0.999);
-        //}
     }
 }


### PR DESCRIPTION
Currently, the scaling logic for the RedisStreamTrigger uses only the stream length to determine the target number of function instances. If all entries in the stream have been acked but not deleted, this logic will return a large target instance count even though there are no entries left to process.

Redis 7 contains a `lag` field in the [`XINFO GROUPS`](https://redis.io/commands/xinfo-groups/) command that allows a client to see the number of unacked entries in a stream for a consumer group. This is used instead of the stream length.

Redis 6 does not contain that field like Redis 7. As a workaround, this PR adds a method for the scaler to estimate the number of unacked entries. This relies on the default format of the stream entry id being [`<millisecondsTime>-<sequenceNumber>`](https://redis.io/docs/data-types/streams/#entry-ids). [`XINFO GROUPS`](https://redis.io/commands/xinfo-groups/) contains information about the last entry ID that the group received, and we can get the IDs of the first and last entry in the stream from [`XINFO STREAM`](https://redis.io/commands/xinfo-stream/). We approximate the number of entries remaining using time:
```
(last-entry-id - last-delievered-id) / (last-entry-id - first-entry-id) * streamLength
```

RedisStreamScaleMonitor does not get access to the function's LogName, only the ShortName. The function's consumer group is currently based on the LogName, meaning that the ScaleMonitor would not be able to accurately call `XINFO GROUPS` to get the last delievered id. In order to make the separately initialized RedisStreamScaleMonitor and RedisStreamListener use the same consumer group, this PR changes the consumer group of the function to the function's short name, as that is available to both.