### PR TITLE
Change creation of RedisAsyncCollector to use an IAsyncConverter

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollector.cs
@@ -33,4 +33,3 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         }
     }
 }
- 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollectorAsyncConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncCollectorAsyncConverter.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Redis
+{
+    /// <summary>
+    /// Used to create the RedisAsyncCollector.
+    /// </summary>
+    internal class RedisAsyncCollectorAsyncConverter : IAsyncConverter<RedisAttribute, IAsyncCollector<string>>
+    {
+        private IConfiguration configuration;
+        private ILogger logger;
+
+        public RedisAsyncCollectorAsyncConverter(IConfiguration configuration, ILogger logger)
+        {
+            this.configuration = configuration;
+            this.logger = logger;
+        }
+
+        public async Task<IAsyncCollector<string>> ConvertAsync(RedisAttribute input, CancellationToken cancellationToken)
+        {
+            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, input.ConnectionStringSetting);
+            return new RedisAsyncCollector(multiplexer, input.Command, logger);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncConverter.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/Bindings/RedisAsyncConverter.cs
@@ -9,13 +9,13 @@ using StackExchange.Redis;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis
 {
-    internal class RedisConverter<T> : IAsyncConverter<RedisAttribute, T>
+    internal class RedisAsyncConverter<T> : IAsyncConverter<RedisAttribute, T>
     {
         private readonly IConfiguration configuration;
         private readonly INameResolver nameResolver;
         private readonly ILogger logger;
 
-        public RedisConverter(IConfiguration configuration, INameResolver nameResolver, ILogger logger)
+        public RedisAsyncConverter(IConfiguration configuration, INameResolver nameResolver, ILogger logger)
         {
             this.configuration = configuration;
             this.nameResolver = nameResolver;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             streamTriggerRule.BindToTrigger(new RedisStreamTriggerBindingProvider(configuration, nameResolver, loggerFactory.CreateLogger(RedisUtilities.RedisStreamTrigger)));
 
             FluentBindingRule<RedisAttribute> bindingRule = context.AddBindingRule<RedisAttribute>();
-            bindingRule.BindToCollector(new RedisAsyncCollectorAsyncConverter(configuration, loggerFactory.CreateLogger(RedisUtilities.RedisInputBinding)));
+            bindingRule.BindToCollector(new RedisAsyncCollectorAsyncConverter(configuration, loggerFactory.CreateLogger(RedisUtilities.RedisOutputBinding)));
             bindingRule.BindToInput<OpenType>(typeof(RedisAsyncConverter<>), configuration, nameResolver, loggerFactory.CreateLogger(RedisUtilities.RedisInputBinding));
 #pragma warning restore CS0618
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisExtensionConfigProvider.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             streamTriggerRule.BindToTrigger(new RedisStreamTriggerBindingProvider(configuration, nameResolver, loggerFactory.CreateLogger(RedisUtilities.RedisStreamTrigger)));
 
             FluentBindingRule<RedisAttribute> bindingRule = context.AddBindingRule<RedisAttribute>();
-            bindingRule.BindToCollector((attr) => new RedisAsyncCollector(GetOrCreateConnectionMultiplexer(configuration, attr.ConnectionStringSetting), attr.Command, loggerFactory.CreateLogger(RedisUtilities.RedisOutputBinding)));
-            bindingRule.BindToInput<OpenType>(typeof(RedisConverter<>), configuration, nameResolver, loggerFactory.CreateLogger(RedisUtilities.RedisInputBinding));
+            bindingRule.BindToCollector(new RedisAsyncCollectorAsyncConverter(configuration, loggerFactory.CreateLogger(RedisUtilities.RedisInputBinding)));
+            bindingRule.BindToInput<OpenType>(typeof(RedisAsyncConverter<>), configuration, nameResolver, loggerFactory.CreateLogger(RedisUtilities.RedisInputBinding));
 #pragma warning restore CS0618
         }
 


### PR DESCRIPTION
#136 and #137 require an async creation of the RedisAsyncCollector, and thus the lambda-based creation cannot be used. This PR changes the creation to use an IAsyncConverter to convert the RedisAttribute into the RedisAsyncCollector.