### PR TITLE
Have each listener and scale provider get own ConnectionMultiplexer instead of being passed in as argument

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListListener.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using System;
@@ -15,12 +16,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
     {
         internal bool listPopFromBeginning;
 
-        public RedisListListener(string name, IConnectionMultiplexer multiplexer, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, bool batch, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, multiplexer, key, pollingInterval, maxBatchSize, batch, executor, logger)
+        public RedisListListener(string name, IConfiguration configuration, string connectionStringSetting, string key, TimeSpan pollingInterval, int maxBatchSize, bool listPopFromBeginning, bool batch, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, configuration, connectionStringSetting, key, pollingInterval, maxBatchSize, batch, executor, logger)
         {
             this.listPopFromBeginning = listPopFromBeginning;
             this.logPrefix = $"[Name:{name}][Trigger:{RedisUtilities.RedisListTrigger}][Key:{key}]";
-            this.scaleMonitor = new RedisListTriggerScaleMonitor(multiplexer, name, maxBatchSize, key);
+            this.scaleMonitor = new RedisListTriggerScaleMonitor(name, configuration, connectionStringSetting, maxBatchSize, key);
         }
 
         public override void BeforePolling()

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerBinding.cs
@@ -64,11 +64,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 logger?.LogError($"[{nameof(RedisListTriggerBinding)}] Provided {nameof(ListenerFactoryContext)} is null.");
                 throw new ArgumentNullException(nameof(context));
             }
-            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting, context.Descriptor.ShortName);
 
             return Task.FromResult<IListener>(new RedisListListener(
                 context.Descriptor.ShortName,
-                multiplexer,
+                configuration,
+                connectionStringSetting,
                 key,
                 pollingInterval,
                 maxBatchSize,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/ListTrigger/RedisListTriggerScaleMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Configuration;
+using StackExchange.Redis;
 using System;
 using System.Threading.Tasks;
 
@@ -21,11 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
         public override async Task<RedisPollingTriggerBaseMetrics> GetMetricsAsync()
         {
-            if (multiplexer is null)
-            {
-                multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting);
-            }
-
+            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting);
             var metrics = new RedisPollingTriggerBaseMetrics
             {
                 Remaining = await multiplexer.GetDatabase().ListLengthAsync(key),

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Configuration;
-using StackExchange.Redis;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,7 +11,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         private const int MINIMUM_SAMPLES = 5;
 
         internal string name;
-        internal IConnectionMultiplexer multiplexer;
         internal IConfiguration configuration;
         internal string connectionStringSetting;
         internal int maxBatchSize;
@@ -23,14 +21,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             this.name = name;
             this.configuration = configuration;
             this.connectionStringSetting = connectionStringSetting;
-            this.maxBatchSize = maxBatchSize;
-            this.key = key;
-        }
-
-        public RedisPollingTriggerBaseScaleMonitor(string name, IConnectionMultiplexer multiplexer, int maxBatchSize, string key)
-        {
-            this.name = name;
-            this.multiplexer = multiplexer;
             this.maxBatchSize = maxBatchSize;
             this.key = key;
         }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/PollingTriggerBase/RedisPollingTriggerBaseScaleMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Extensions.Configuration;
 using StackExchange.Redis;
 using System;
 using System.Linq;
@@ -12,8 +13,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
         internal string name;
         internal IConnectionMultiplexer multiplexer;
+        internal IConfiguration configuration;
+        internal string connectionStringSetting;
         internal int maxBatchSize;
         internal string key;
+
+        public RedisPollingTriggerBaseScaleMonitor(string name, IConfiguration configuration, string connectionStringSetting, int maxBatchSize, string key)
+        {
+            this.name = name;
+            this.configuration = configuration;
+            this.connectionStringSetting = connectionStringSetting;
+            this.maxBatchSize = maxBatchSize;
+            this.key = key;
+        }
 
         public RedisPollingTriggerBaseScaleMonitor(string name, IConnectionMultiplexer multiplexer, int maxBatchSize, string key)
         {
@@ -22,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             this.maxBatchSize = maxBatchSize;
             this.key = key;
         }
-        
+
         public ScaleMonitorDescriptor Descriptor { get; internal set; }
         public TargetScalerDescriptor TargetScalerDescriptor { get; internal set; }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisScalerProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/RedisScalerProvider.cs
@@ -1,9 +1,7 @@
-﻿using Microsoft.Azure.WebJobs.Description;
-using Microsoft.Azure.WebJobs.Host.Scale;
+﻿using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
-using StackExchange.Redis;
 using System;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Redis
@@ -28,17 +26,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
             INameResolver nameResolver = serviceProvider.GetService<INameResolver>();
 
             RedisPollingTriggerMetadata metadata = JsonConvert.DeserializeObject<RedisPollingTriggerMetadata>(triggerMetadata.Metadata.ToString());
-            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, metadata.connectionStringSetting);
-            int maxBatchSize = metadata.maxBatchSize;
             string key = RedisUtilities.ResolveString(nameResolver, metadata.key, nameof(metadata.key));
 
             if (string.Equals(triggerMetadata.Type, RedisUtilities.RedisListTrigger, StringComparison.OrdinalIgnoreCase))
             {
-                scaleMonitor = new RedisListTriggerScaleMonitor(multiplexer, triggerMetadata.FunctionName, maxBatchSize, key);
+                scaleMonitor = new RedisListTriggerScaleMonitor(triggerMetadata.FunctionName, configuration, metadata.connectionStringSetting, metadata.maxBatchSize, key);
             }
             else if (string.Equals(triggerMetadata.Type, RedisUtilities.RedisStreamTrigger, StringComparison.OrdinalIgnoreCase))
             {
-                scaleMonitor = new RedisStreamTriggerScaleMonitor(multiplexer, triggerMetadata.FunctionName, maxBatchSize, key);
+                scaleMonitor = new RedisStreamTriggerScaleMonitor(triggerMetadata.FunctionName, configuration, metadata.connectionStringSetting, metadata.maxBatchSize, key);
             }
             else
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamListener.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 using System;
@@ -16,12 +17,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
         internal string consumerName;
         internal string entriesReadKey;
 
-        public RedisStreamListener(string name, IConnectionMultiplexer multiplexer, string key, TimeSpan pollingInterval, int maxBatchSize, bool batch, ITriggeredFunctionExecutor executor, ILogger logger)
-            : base(name, multiplexer, key, pollingInterval, maxBatchSize, batch, executor, logger)
+        public RedisStreamListener(string name, IConfiguration configuration, string connectionStringSetting, string key, TimeSpan pollingInterval, int maxBatchSize, bool batch, ITriggeredFunctionExecutor executor, ILogger logger)
+            : base(name, configuration, connectionStringSetting, key, pollingInterval, maxBatchSize, batch, executor, logger)
         {
             this.consumerName = Environment.GetEnvironmentVariable("WEBSITE_INSTANCE_ID") ?? Guid.NewGuid().ToString();
             this.logPrefix = $"[Name:{name}][Trigger:{RedisUtilities.RedisStreamTrigger}][ConsumerGroup:{name}][Key:{key}][Consumer:{consumerName}]";
-            this.scaleMonitor = new RedisStreamTriggerScaleMonitor(multiplexer, name, maxBatchSize, key);
+            this.scaleMonitor = new RedisStreamTriggerScaleMonitor(name, configuration, connectionStringSetting, maxBatchSize, key);
             this.entriesReadKey = RedisScalerProvider.GetFunctionScalerId(name, RedisUtilities.RedisStreamTrigger, key);
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerBinding.cs
@@ -62,10 +62,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
                 throw new ArgumentNullException(nameof(context));
             }
 
-            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting, context.Descriptor.ShortName);
             return Task.FromResult<IListener>(new RedisStreamListener(
-                context.Descriptor.LogName,
-                multiplexer,
+                context.Descriptor.ShortName,
+                configuration,
+                connectionStringSetting,
                 key,
                 pollingInterval,
                 maxBatchSize,

--- a/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Redis/StreamTrigger/RedisStreamTriggerScaleMonitor.cs
@@ -23,11 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis
 
         public override async Task<RedisPollingTriggerBaseMetrics> GetMetricsAsync()
         {
-            if (multiplexer is null)
-            {
-                multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting);
-            }
-
+            IConnectionMultiplexer multiplexer = RedisExtensionConfigProvider.GetOrCreateConnectionMultiplexer(configuration, connectionStringSetting);
             long streamLength = await multiplexer.GetDatabase().StreamLengthAsync(key);
             if (streamLength == 0)
             {

--- a/test/dotnet/Unit/RedisPollingTriggerBaseScaleMonitorTests.cs
+++ b/test/dotnet/Unit/RedisPollingTriggerBaseScaleMonitorTests.cs
@@ -1,10 +1,8 @@
 ﻿using FakeItEasy;
-using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 using StackExchange.Redis;
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,11 +10,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
 {
     public class RedisPollingTriggerBaseScaleMonitorTests
     {
-        private const string name = nameof(RedisPollingTriggerBaseScaleMonitorTests);
-        private const int defaultBatchSize = 10;
-        private const string key = "a";
-        private TimeSpan defaultPollingInterval = TimeSpan.FromMilliseconds(100);
-
         private static readonly RedisPollingTriggerBaseMetrics[] increasingMetrics = new RedisPollingTriggerBaseMetrics[] {
             new RedisPollingTriggerBaseMetrics { Timestamp = DateTime.Now.AddSeconds(-9), Remaining = 10 },
             new RedisPollingTriggerBaseMetrics { Timestamp = DateTime.Now.AddSeconds(-8), Remaining = 20 },
@@ -60,16 +53,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
             new RedisPollingTriggerBaseMetrics { Timestamp = DateTime.Now.AddSeconds(-1), Remaining = 50 },
         };
 
-        [Fact]
-        public async void StopAsync_ClosesAndDisposesConnectionMultiplexerAsync()
-        {
-            IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, defaultBatchSize, false, true, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
-            await listener.StopAsync(new CancellationToken());
-            A.CallTo(() => listener.multiplexer.CloseAsync(A<bool>._)).MustHaveHappened();
-            A.CallTo(() => listener.multiplexer.DisposeAsync()).MustHaveHappened();
-        }
-
         [Theory]
         [InlineData(1, 10, ScaleVote.ScaleOut)]
         [InlineData(5, 5, ScaleVote.ScaleOut)]
@@ -79,10 +62,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(5, 20, ScaleVote.ScaleIn)]
         public void ScalingLogic_ConstantMetrics(int workerCount, int batchSize, ScaleVote expected)
         {
-            IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, true, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseScaleMonitor monitor = new RedisListTriggerScaleMonitor("name", A.Fake<IConfiguration>(), "connection", batchSize, "key");
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = constantMetrics };
-            Assert.Equal(expected, listener.GetMonitor().GetScaleStatus(context).Vote);
+            Assert.Equal(expected, monitor.GetScaleStatus(context).Vote);
         }
 
         [Theory]
@@ -94,10 +76,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(5, 20)]
         public void ScalingLogic_FewMetrics(int workerCount, int batchSize)
         {
-            IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, true, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseScaleMonitor monitor = new RedisListTriggerScaleMonitor("name", A.Fake<IConfiguration>(), "connection", batchSize, "key");
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = fewMetrics };
-            Assert.Equal(ScaleVote.None, listener.GetMonitor().GetScaleStatus(context).Vote);
+            Assert.Equal(ScaleVote.None, monitor.GetScaleStatus(context).Vote);
         }
 
         [Theory]
@@ -107,10 +88,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(10, 10, ScaleVote.ScaleIn)]
         public void ScalingLogic_DecreasingMetrics(int workerCount, int batchSize, ScaleVote expected)
         {
-            IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, true, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseScaleMonitor monitor = new RedisListTriggerScaleMonitor("name", A.Fake<IConfiguration>(), "connection", batchSize, "key");
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = decreasingMetrics };
-            Assert.Equal(expected, listener.GetMonitor().GetScaleStatus(context).Vote);
+            Assert.Equal(expected, monitor.GetScaleStatus(context).Vote);
         }
         [Theory]
         [InlineData(1, 10, ScaleVote.ScaleOut)]
@@ -119,10 +99,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(10, 10, ScaleVote.ScaleIn)]
         public void ScalingLogic_IncreasingMetrics(int workerCount, int batchSize, ScaleVote expected)
         {
-            IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, true, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
+            RedisPollingTriggerBaseScaleMonitor monitor = new RedisListTriggerScaleMonitor("name", A.Fake<IConfiguration>(), "connection", batchSize, "key");
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = increasingMetrics };
-            Assert.Equal(expected, listener.GetMonitor().GetScaleStatus(context).Vote);
+            Assert.Equal(expected, monitor.GetScaleStatus(context).Vote);
         }
 
         [Theory]
@@ -135,12 +114,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
         [InlineData(10000, 10, 1000)]
         public async Task TargetScaler_IncreasingMetricsAsync(long remaining, int batchSize, int expected)
         {
+            RedisPollingTriggerBaseScaleMonitor monitor = new RedisListTriggerScaleMonitor("name", A.Fake<IConfiguration>(), "connection", batchSize, "key");
             IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
             IDatabase fakeDatabase = A.Fake<IDatabase>();
             A.CallTo(() => multiplexer.GetDatabase(A<int>._, A<object>._)).Returns(fakeDatabase);
             A.CallTo(() => fakeDatabase.ListLength(A<RedisKey>._, A<CommandFlags>._)).Returns(remaining);
-            RedisPollingTriggerBaseListener listener = new RedisListListener(name, multiplexer, key, defaultPollingInterval, batchSize, false, true, A.Fake<ITriggeredFunctionExecutor>(), A.Fake<ILogger>());
-            Assert.Equal(expected, (await listener.GetTargetScaler().GetScaleResultAsync(null)).TargetWorkerCount);
+            A.CallTo(() => fakeDatabase.ListLengthAsync(A<RedisKey>._, A<CommandFlags>._)).Returns(remaining);
+            monitor.multiplexer = multiplexer;
+            Assert.Equal(expected, (await monitor.GetScaleResultAsync(null)).TargetWorkerCount);
         }
     }
 }

--- a/test/dotnet/Unit/RedisPollingTriggerBaseScaleMonitorTests.cs
+++ b/test/dotnet/Unit/RedisPollingTriggerBaseScaleMonitorTests.cs
@@ -103,25 +103,5 @@ namespace Microsoft.Azure.WebJobs.Extensions.Redis.Tests.Unit
             ScaleStatusContext context = new ScaleStatusContext { WorkerCount = workerCount, Metrics = increasingMetrics };
             Assert.Equal(expected, monitor.GetScaleStatus(context).Vote);
         }
-
-        [Theory]
-        [InlineData(10, 10, 1)]
-        [InlineData(50, 10, 5)]
-        [InlineData(100, 10, 10)]
-        [InlineData(500, 10, 50)]
-        [InlineData(1000, 50, 20)]
-        [InlineData(5000, 100, 50)]
-        [InlineData(10000, 10, 1000)]
-        public async Task TargetScaler_IncreasingMetricsAsync(long remaining, int batchSize, int expected)
-        {
-            RedisPollingTriggerBaseScaleMonitor monitor = new RedisListTriggerScaleMonitor("name", A.Fake<IConfiguration>(), "connection", batchSize, "key");
-            IConnectionMultiplexer multiplexer = A.Fake<IConnectionMultiplexer>();
-            IDatabase fakeDatabase = A.Fake<IDatabase>();
-            A.CallTo(() => multiplexer.GetDatabase(A<int>._, A<object>._)).Returns(fakeDatabase);
-            A.CallTo(() => fakeDatabase.ListLength(A<RedisKey>._, A<CommandFlags>._)).Returns(remaining);
-            A.CallTo(() => fakeDatabase.ListLengthAsync(A<RedisKey>._, A<CommandFlags>._)).Returns(remaining);
-            monitor.multiplexer = multiplexer;
-            Assert.Equal(expected, (await monitor.GetScaleResultAsync(null)).TargetWorkerCount);
-        }
     }
 }


### PR DESCRIPTION
For #136, changing logic of all listeners and scaler providers to create their own connection multiplexer. This will minimize changes later to connection creation logic when moving to an `async` creation function.