### PR TITLE
Remove java annotation default values

### DIFF
--- a/samples/java/src/main/java/com/function/RedisInputBinding/SetGetter.java
+++ b/samples/java/src/main/java/com/function/RedisInputBinding/SetGetter.java
@@ -10,7 +10,8 @@ public class SetGetter {
             @RedisPubSubTrigger(
                 name = "key",
                 connection = "redisConnectionString",
-                channel = "__keyevent@0__:set")
+                channel = "__keyevent@0__:set",
+                pattern = false)
                 String key,
             @RedisInput(
                 name = "value",

--- a/samples/java/src/main/java/com/function/RedisListTrigger/FastPollingListTrigger.java
+++ b/samples/java/src/main/java/com/function/RedisListTrigger/FastPollingListTrigger.java
@@ -12,7 +12,8 @@ public class FastPollingListTrigger {
                 connection = "redisConnectionString",
                 key = "listTest",
                 pollingIntervalInMs = 100,
-                maxBatchSize = 1)
+                maxBatchSize = 1,
+                listDirection = ListDirection.LEFT)
                 String message,
             final ExecutionContext context) {
             context.getLogger().info(message);

--- a/samples/java/src/main/java/com/function/RedisListTrigger/SimpleListTrigger.java
+++ b/samples/java/src/main/java/com/function/RedisListTrigger/SimpleListTrigger.java
@@ -12,7 +12,8 @@ public class SimpleListTrigger {
                 connection = "redisConnectionString",
                 key = "listTest",
                 pollingIntervalInMs = 1000,
-                maxBatchSize = 1)
+                maxBatchSize = 1,
+                listDirection = ListDirection.LEFT)
                 String message,
             final ExecutionContext context) {
             context.getLogger().info(message);

--- a/samples/java/src/main/java/com/function/RedisOutputBinding/SetDeleter.java
+++ b/samples/java/src/main/java/com/function/RedisOutputBinding/SetDeleter.java
@@ -14,7 +14,8 @@ public class SetDeleter {
             @RedisPubSubTrigger(
                 name = "key",
                 connection = "redisConnectionString",
-                channel = "__keyevent@0__:set")
+                channel = "__keyevent@0__:set",
+                pattern = false)
                 String key,
             final ExecutionContext context) {
         context.getLogger().info("Deleting recently SET key '" + key + "'");

--- a/samples/java/src/main/java/com/function/RedisOutputBinding/StreamTriggerDeleteEntry.java
+++ b/samples/java/src/main/java/com/function/RedisOutputBinding/StreamTriggerDeleteEntry.java
@@ -11,7 +11,9 @@ public class StreamTriggerDeleteEntry {
             @RedisStreamTrigger(
                 name = "entry",
                 connection = "redisConnectionString",
-                key = "streamTest2")
+                key = "streamTest2",
+                pollingIntervalInMs = 1000,
+                maxBatchSize = 1)
                 RedisStreamEntry entry,
             @RedisOutput(
                 name = "value",

--- a/samples/java/src/main/java/com/function/RedisPubSubTrigger/KeyeventTrigger.java
+++ b/samples/java/src/main/java/com/function/RedisPubSubTrigger/KeyeventTrigger.java
@@ -10,7 +10,8 @@ public class KeyeventTrigger {
             @RedisPubSubTrigger(
                 name = "req",
                 connection = "redisConnectionString",
-                channel = "__keyevent@0__:del")
+                channel = "__keyevent@0__:del",
+                pattern = false)
                 String message,
             final ExecutionContext context) {
             context.getLogger().info(message);

--- a/samples/java/src/main/java/com/function/RedisPubSubTrigger/KeyspaceTrigger.java
+++ b/samples/java/src/main/java/com/function/RedisPubSubTrigger/KeyspaceTrigger.java
@@ -10,7 +10,8 @@ public class KeyspaceTrigger {
             @RedisPubSubTrigger(
                 name = "req",
                 connection = "redisConnectionString",
-                channel = "__keyspace@0__:keyspaceTest")
+                channel = "__keyspace@0__:keyspaceTest",
+                pattern = false)
                 String message,
             final ExecutionContext context) {
             context.getLogger().info(message);

--- a/samples/java/src/main/java/com/function/RedisPubSubTrigger/ResolvedChannelPubSubTrigger.java
+++ b/samples/java/src/main/java/com/function/RedisPubSubTrigger/ResolvedChannelPubSubTrigger.java
@@ -10,7 +10,8 @@ public class ResolvedChannelPubSubTrigger {
             @RedisPubSubTrigger(
                 name = "req",
                 connection = "redisConnectionString",
-                channel = "%pubsubChannel%")
+                channel = "%pubsubChannel%",
+                pattern = false)
                 String message,
             final ExecutionContext context) {
             context.getLogger().info(message);

--- a/samples/java/src/main/java/com/function/RedisPubSubTrigger/SimplePubSubTrigger.java
+++ b/samples/java/src/main/java/com/function/RedisPubSubTrigger/SimplePubSubTrigger.java
@@ -10,7 +10,8 @@ public class SimplePubSubTrigger {
             @RedisPubSubTrigger(
                 name = "req",
                 connection = "redisConnectionString",
-                channel = "pubsubTest")
+                channel = "pubsubTest",
+                pattern = false)
                 String message,
             final ExecutionContext context) {
             context.getLogger().info(message);

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisListTrigger.java
@@ -66,17 +66,17 @@ public @interface RedisListTrigger {
      * How often to poll Redis in milliseconds.
      * @return How often to poll Redis in milliseconds.
      */
-    int pollingIntervalInMs() default 1000;
+    int pollingIntervalInMs();
 
     /**
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */
-    int maxBatchSize() default 16;
+    int maxBatchSize();
 
     /**
      * The direction to pop elements from the list..
      * @return The direction to pop elements from the list.
      */
-    ListDirection listDirection() default ListDirection.LEFT;
+    ListDirection listDirection();
 }

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisPubSubTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisPubSubTrigger.java
@@ -65,5 +65,5 @@ public @interface RedisPubSubTrigger {
     /**
      * If the given channel is a pattern.
      */
-    boolean pattern() default false;
+    boolean pattern();
 }

--- a/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
+++ b/src/azure-functions-java-library-redis/src/main/java/com/microsoft/azure/functions/redis/annotation/RedisStreamTrigger.java
@@ -66,11 +66,11 @@ public @interface RedisStreamTrigger {
      * How often to poll Redis in milliseconds.
      * @return How often to poll Redis in milliseconds.
      */
-    int pollingIntervalInMs() default 1000;
+    int pollingIntervalInMs();
 
     /**
      * Number of entries to pull from Redis at one time.
      * @return Number of entries to pull from Redis at one time.
      */
-    int maxBatchSize() default 16;
+    int maxBatchSize();
 }


### PR DESCRIPTION
There is an issue where `default` values in java do not show up in the corresponding `function.json` file: #151 
This PR removes the defaults.